### PR TITLE
HTTPS is the way

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "concat-stream": "^1.5.2",
     "create-html": "^3.0.0",
     "css-extract": "^1.2.0",
+    "devcert": "^0.3.2",
     "disc": "^1.3.2",
     "envify": "^4.0.0",
     "explain-error": "^1.0.3",


### PR DESCRIPTION
That `.default` thing caught me for a minute.  Really wish there was better
interop between cjs and ecmascript modules... Not sure if the `.default` is 
better on the require (so the API works as "expected" w/r/t to cjs) or if you
want `devCert.default()` when invoking it.

Plus the `{installCertutil: true}` option doesn't seem to work on my mac at the
very least, as [chrome and firefox still give security warnings](https://github.com/davewasmer/devcert/issues/4)?


Lastly should we be only HTTPS or HTTP by default with HTTPS opt-in or HTTPS
by default or HTTP opt-in

I figure if we can get this working on multiple platforms without security
issues there's no reason not to do HTTPS-only?