### PR TITLE
Fix favicon issue in firefox

### DIFF
--- a/bin/start.js
+++ b/bin/start.js
@@ -87,7 +87,7 @@ function start (entry, argv, done) {
     } else if (url === '/manifest.json') {
       assert.ok(argv.html.manifest, 'bankai.start: no manifest file found')
       fs.createReadStream(argv.html.manifest).pipe(zlibMaybe(req, res)).pipe(res)
-    } else if (url === '/' || req.headers['accept'].indexOf('html') > 0) {
+    } else if ((url === '/' || req.headers['accept'].indexOf('html') > 0) && req.url.indexOf('favicon') === -1) {
       if (fs.existsSync(path.join(process.cwd(), 'index.html'))) {
         fs.createReadStream(path.join(process.cwd(), 'index.html')).pipe(res)
       } else {


### PR DESCRIPTION
Firefox is requesting `/favicon.ico` with an accept header containing `html`
in it, so it gets caught by the html send function. This fixes that and
avoids trying to send favicon.ico as an HTML file

Fixes #217 