### PR TITLE
fix(cli): update bad package.json require path

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -88,7 +88,7 @@ function main (argv) {
     console.log(usage)
     return process.exit()
   } else if (argv.v) {
-    console.log(require('./package.json').version)
+    console.log(require('../package.json').version)
     return process.exit()
   }
 


### PR DESCRIPTION
Noticed `bankai --version` throws after running `create-choo-app` to debug another issue.

```
^C~/dev/lab/cca (master) $ bankai --version
module.js:491
    throw err;
    ^

Error: Cannot find module './package.json'
    at Function.Module._resolveFilename (module.js:489:15)
    at Function.Module._load (module.js:439:25)
    at Module.require (module.js:517:17)
    at require (internal/module.js:11:18)
    at main (/Users/ng/dev/lab/cca/node_modules/bankai/bin/index.js:91:17)
    at Object.<anonymous> (/Users/ng/dev/lab/cca/node_modules/bankai/bin/index.js:80:1)
    at Module._compile (module.js:573:30)
    at Object.Module._extensions..js (module.js:584:10)
    at Module.load (module.js:507:32)
    at tryModuleLoad (module.js:470:12)
```

Easy fix (`'./package.json'` -> `'../package.json'`)