### PR TITLE
check if process is TTY before hooking up keypress

### DIFF
--- a/lib/graph-document.js
+++ b/lib/graph-document.js
@@ -95,7 +95,7 @@ function scriptTransform (opts) {
 function styleTransform (opts) {
   var hash = opts.hash
   var link = `/${hash}/bundle.css`
-  var header = `<link rel="preload" as="style" href="${link}" onload="this.rel='stylesheet'">`
+  var header = `<link rel="stylesheet" href="${link}">`
   return addToHead(header)
 }
 

--- a/lib/graph-document.js
+++ b/lib/graph-document.js
@@ -95,7 +95,7 @@ function scriptTransform (opts) {
 function styleTransform (opts) {
   var hash = opts.hash
   var link = `/${hash}/bundle.css`
-  var header = `<link rel="stylesheet" href="${link}">`
+  var header = `<link rel="preload" as="style" href="${link}" onload="this.rel='stylesheet'">`
   return addToHead(header)
 }
 

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -29,10 +29,12 @@ function render (state) {
 
   process.stdout.on('resize', onresize)
 
-  keypress(process.stdin)
-  process.stdin.setRawMode(true)
-  process.stdin.resume()
-  process.stdin.on('keypress', onkeypress)
+  if (process.stdin.isTTY) {
+    keypress(process.stdin)
+    process.stdin.setRawMode(true)
+    process.stdin.resume()
+    process.stdin.on('keypress', onkeypress)
+  }
 
   return render
 


### PR DESCRIPTION
I'm using `heroku local` to set up some environment variables before shelling out to my Node server. This fix allows Bankai to run without throwing (in non-TTY environments, I believe `setRawMode` is undefined).