### PR TITLE
Enable unassertify during `bankai build`

### DIFF
--- a/lib/cmd-build.js
+++ b/lib/cmd-build.js
@@ -23,6 +23,7 @@ function build (entry, opts) {
 
     var bankaiOpts = {
       logStream: pumpify(pinoColada(), stdout),
+      assert: false,
       watch: false
     }
     var compiler = bankai(entry, bankaiOpts)

--- a/lib/graph-script.js
+++ b/lib/graph-script.js
@@ -44,7 +44,7 @@ function node (state, createEdge) {
   b.ignore('sheetify/insert')
   b.transform(sheetify)
 
-  if (this.assert) b.transform(unassertify, { global: true })
+  if (!state.metadata.assert) b.transform(unassertify, { global: true })
   b.transform(brfs)
   b.transform(glslify)
   b.transform(yoyoify, { global: true })


### PR DESCRIPTION
Pass `assert: false` option, enabling unassertify.

I'm not sure if that's the way the option was intended to work, but
passing `assert: false` to remove asserts makes sense to me, so :)