### PR TITLE
add module deps

### DIFF
--- a/http.js
+++ b/http.js
@@ -170,6 +170,17 @@ function start (entry, opts) {
     })
   })
 
+  router.route(/\/module-deps\.json/, function (req, res) {
+    compiler.moduleDeps(function (err, json) {
+      if (err) {
+        res.statusCode = 404
+        return res.end(err.message)
+      }
+      res.setHeader('content-type', 'application/json')
+      gzip(json, req, res)
+    })
+  })
+
   router.route(/\/reload/, function sse (req, res) {
     var connected = true
     emitter.on('scripts:bundle', reloadScript)

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var assert = require('assert')
 var path = require('path')
 var pino = require('pino')
 
+var moduleDeps = require('./lib/module-deps')
 var localization = require('./localization')
 var queue = require('./lib/queue')
 
@@ -115,6 +116,7 @@ function Bankai (entry, opts) {
     }
   })
 
+  this.entry = entry
   this.metadata = this.graph.metadata
 }
 Bankai.prototype = Object.create(Emitter.prototype)
@@ -203,6 +205,10 @@ Bankai.prototype.sourceMaps = function (stepName, edgeName, cb) {
   var data = self.graph.data[stepName][edgeName]
   if (!data) return cb(new Error('bankai.sourceMaps: could not find a file for ' + stepName + ':' + edgeName))
   cb(null, data)
+}
+
+Bankai.prototype.moduleDeps = function (cb) {
+  moduleDeps(this.entry, cb)
 }
 
 Bankai.prototype.close = function () {

--- a/lib/module-deps.js
+++ b/lib/module-deps.js
@@ -1,0 +1,17 @@
+var concat = require('concat-stream')
+var mdeps = require('module-deps')
+var pump = require('pump')
+
+module.exports = moduleDeps
+
+function moduleDeps (entry, done) {
+  var md = mdeps()
+  md.end({ file: entry })
+  pump(md, concat({ encoding: 'object' }, function (obj) {
+    var json = JSON.stringify(obj)
+    done(null, json)
+  }), end)
+
+  function end () {
+  }
+}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "keypress": "^0.2.1",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
+    "module-deps": "^4.1.1",
     "nanologger": "^1.3.1",
     "nanoraf": "^3.0.1",
     "nanotiming": "^6.1.3",


### PR DESCRIPTION
Adds an overview of all used modules in the project, and their respective locations. Done on request of @jasonlaster so browsers like FireFox can figure out more about the code (e.g. walk it themselves).

The idea is to add an extra comment at the end of the bundle similar to source maps to indicate where to retrieve the module deps. This isn't part of this PR yet, because we're not completely sure what that would look like.

Furthermore this is also something that can later be adopted by other bundlers such as WebPack.

---

cc/ @jsonlaster could you link to the related issues in FireFox so we can add some more context? Thanks! :grin: