### PR TITLE
Fix minify source mapping, fixes #275

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -1,7 +1,6 @@
 var convert = require('convert-source-map')
 var uglify = require('uglify-es')
 var assert = require('assert')
-var path = require('path')
 
 // NOTE: This whole file is insanity. Uglify requires all sorts of mapping to
 // preserve source maps. Because of `common-shakeify` in our graph-scripts can
@@ -19,35 +18,14 @@ function minify (entry, buffer, cb) {
 
   buffer = String(buffer)
   var opts = uglifyOpts(entry)
-  var matched = buffer.match(
-    // match an inlined sourceMap with or without a charset definition
-    /\/\/[#@] ?sourceMappingURL=data:application\/json(?:;charset=utf-8)?;base64,([a-zA-Z0-9+/]+)={0,2}\n?$/
-  )
-
-  // Check if incoming source code already has source map comment.
-  // If so, send it in to ujs.minify as the inSourceMap parameter
-  if (matched) {
-    opts.sourceMap.content = convert
-      .fromJSON(Buffer.from(matched[1], 'base64').toString())
-      .sourcemap
-  }
 
   var min = uglify.minify(buffer, opts)
-  var str = ''
 
   if (min.error) return cb(min.error)
-  min.code = min.code.replace(/\/\/[#@] ?sourceMappingURL=out.js.map$/, '')
-  str += min.code
+  var str = min.code
 
   if (min.map && min.map !== 'null') {
-    var map = convert.fromJSON(min.map)
-    map.setProperty('sources', [path.basename(entry)])
-    map.setProperty('sourcesContent', matched
-      ? opts.sourceMap.sourcesContent
-      : [buffer]
-    )
-    str += '\n'
-    str += map.toComment()
+    str += '\n' + convert.fromJSON(min.map).toComment()
   }
 
   var bundle = Buffer.from(str)
@@ -68,9 +46,6 @@ function uglifyOpts (entry, otherOpts) {
       reduce_vars: true,
       collapse_vars: true
     },
-    sourceMap: {
-      filename: entry,
-      url: 'out.js.map'
-    }
+    sourceMap: { content: 'inline' }
   }
 }

--- a/lib/minify.js
+++ b/lib/minify.js
@@ -2,12 +2,8 @@ var convert = require('convert-source-map')
 var uglify = require('uglify-es')
 var assert = require('assert')
 
-// NOTE: This whole file is insanity. Uglify requires all sorts of mapping to
-// preserve source maps. Because of `common-shakeify` in our graph-scripts can
-// only operate on unminified code, we had to dismantle uglifyify and run it
-// after browserify is done. Almost every piece of config in this file seems
-// arbitrary & is prone to workarounds; only touch it if you're sure uglify
-// is causing trouble.
+// Because `common-shakeify` in our graph-scripts can only operate on
+// unminified code, we have to manually run uglify after browserify is done.
 
 module.exports = minify
 


### PR DESCRIPTION
I'm not sure what was causing it, I think maybe the `sourcesContent` overrides
that were in there previously? Then because the source files are not being
served either, the browser doesn't know what sourcemapped files look like.

Whatever it was, using uglify's built-in inline source map detection seems to
work :tada: