### PR TITLE
Enable ascii_only output to prevent utf8 mangling

### DIFF
--- a/lib/minify.js
+++ b/lib/minify.js
@@ -42,6 +42,9 @@ function uglifyOpts (entry, otherOpts) {
       reduce_vars: true,
       collapse_vars: true
     },
+    output: {
+      ascii_only: true
+    },
     sourceMap: { content: 'inline' }
   }
 }


### PR DESCRIPTION
Uglify seems to have a bad time at parsing/handling UTF-8 characters, and the
`ascii_only: false` default is the culprit.

Switching this on causes the UTF-8 garbage to disappear!