### PR TITLE
gracefully deal with SSR errors

### DIFF
--- a/http.js
+++ b/http.js
@@ -62,6 +62,10 @@ function start (entry, opts) {
     if (!quiet) render()
   })
 
+  compiler.on('ssr', function (result) {
+    state.ssr = result
+  })
+
   compiler.on('change', function (nodeName, edgeName, nodeState) {
     var node = nodeState[nodeName][edgeName]
     var name = nodeName + ':' + edgeName

--- a/index.js
+++ b/index.js
@@ -84,6 +84,10 @@ function Bankai (entry, opts) {
     self.emit('progress', chunk, value)
   })
 
+  this.graph.on('ssr', function (result) {
+    self.emit('ssr', result)
+  })
+
   // Insert nodes into the graph.
   this.graph.node('assets', assetsNode)
   // this.graph.node('document', [ 'manifest:color', 'style:bundle', 'assets:favicons', 'script:bundle' ], documentNode)

--- a/lib/cmd-build.js
+++ b/lib/cmd-build.js
@@ -39,6 +39,10 @@ function build (entry, opts) {
       }
     })
 
+    compiler.on('ssr', function (result) {
+      if (!result.success) log.warn('Server Side Rendering Skipped due to error: ' + result.error.message)
+    })
+
     compiler.on('change', function (nodeName, edgeName, nodeState) {
       var stepName = nodeName + ':' + edgeName
       if (stepName === 'assets:list') writeAssets('assets')

--- a/lib/graph-document.js
+++ b/lib/graph-document.js
@@ -25,6 +25,13 @@ function node (state, createEdge) {
       err = ttyError('documents', entry, err)
       return self.emit('error', 'documents', entry, err)
     }
+
+    if (render.ssrError) {
+      self.emit('ssr', {success: false, error: render.ssrError})
+    } else {
+      self.emit('ssr', {success: true})
+    }
+
     var fonts = extractFonts(state.assets)
     var list = render.list
 

--- a/lib/server-render.js
+++ b/lib/server-render.js
@@ -28,7 +28,7 @@ function serverRender (entry, cb) {
     app = proxyquire(entry, {})
   } catch (err) {
     var failedRequire = err.message === `Cannot find module '${entry}'`
-    if (!failedRequire) return cb(err)
+    if (!failedRequire) render.ssrError = err
     app = null
   }
 

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -93,6 +93,14 @@ function view (state) {
     return str + '\n'
   }, '') + '\n'
 
+  var ssrState = 'Pending'
+
+  if (state.ssr) {
+    if (state.ssr.success) ssrState = 'Success'
+    else ssrState = 'Skipped - ' + state.ssr.error.message
+  }
+  str += 'Server Side Rendering: ' + ssrState + '\n'
+
   str += footer(state)
 
   return str


### PR DESCRIPTION
May need to make it prettier before being accepted, but...

`bankai start`:
![foo](https://user-images.githubusercontent.com/360233/31412964-c43e7de8-addc-11e7-96c6-3a08698cef06.gif)

`bankai build`:

```bash
16:57:30 ✨  Compiling & compressing files

16:57:30 ✨  created: client/dist
16:57:30 ✨  created: client/dist/manifest.json
16:57:30 ✨  created: client/dist/assets/bestbuy-logo.png
16:57:30 ✨  created: client/dist/assets/headerFooterIcons.ttf
16:57:30 ✨  created: client/dist/assets/stars.png
16:57:30 ✨  created: client/dist/manifest.json.gz
16:57:30 ✨  created: client/dist/manifest.json.deflate
16:57:30 ✨  created: client/dist/manifest.json.br
16:57:32 ⚠️  Server Side Rendering Skipped due to error: window is not defined
16:57:32 ✨  created: client/dist/f87876b8465faae9/bundle.css
16:57:32 ✨  created: client/dist/bd682d0267e05d42/bundle.js
16:57:33 ✨  created: client/dist/f87876b8465faae9/bundle.css.gz
16:57:33 ✨  created: client/dist/bd682d0267e05d42/bundle.js.gz
16:57:33 ✨  created: client/dist/index.html
16:57:33 ✨  created: client/dist/index.html.gz
16:57:33 ✨  created: client/dist/f87876b8465faae9/bundle.css.deflate
16:57:33 ✨  created: client/dist/index.html.deflate
16:57:33 ✨  created: client/dist/bd682d0267e05d42/bundle.js.deflate
16:57:33 ✨  created: client/dist/sw.js
16:57:33 ✨  created: client/dist/index.html.br
16:57:33 ✨  created: client/dist/sw.js.gz
16:57:33 ✨  created: client/dist/sw.js.deflate
16:57:33 ✨  created: client/dist/sw.js.br
16:57:33 ✨  created: client/dist/f87876b8465faae9/bundle.css.br
16:57:33 ✨  created: client/dist/bd682d0267e05d42/bundle.js.br
```