### PR TITLE
Use NODE_ENV (or fall back to 'production' if not set) when running build

### DIFF
--- a/lib/cmd-build.js
+++ b/lib/cmd-build.js
@@ -12,6 +12,8 @@ var fs = require('fs')
 var bankai = require('../')
 var utils = require('./utils')
 
+process.env.NODE_ENV = process.env.NODE_ENV || 'production'
+
 module.exports = build
 
 function build (entry, opts) {


### PR DESCRIPTION
As suggested by @yoshuawuyts in https://github.com/choojs/create-choo-electron/issues/1 this PR sets `NODE_ENV` to 'production' by default when running `bankai build`. 

If desired a user can set their own `NODE_ENV` which will override the default.

I tested this in `create-choo-app` by running `npm run dev` and being able to see `choo-log` output in the console. I then ran `npm run build`and served the built files statically and saw no more logs in the console.

I also ran `NODE_ENV="chugga-chugga-choo-choo" npm run build` which meant the 'production' default was overridden and this resulted in `choo-log` being used as expected.

Tests seem to be failing in CI so I don't think I've regressed anything but happy to take a look at that if I have (or take a look separately).