### PR TITLE
full reset and render on terminal resize

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -43,6 +43,8 @@ function render (state) {
   }
 
   function onresize () {
+    console.clear()
+    diff.reset()
     render()
   }
 


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/360233/31559797-8db9342e-b017-11e7-82ec-9ec0cbe6b035.gif)

After:
![after](https://user-images.githubusercontent.com/360233/31559803-9446f20e-b017-11e7-967a-afadf10e58dc.gif)

The `console.reset()` feels a little hacky, but `differ` does not seem to deal with the extra cruft when resetting/clearing. Maybe this is good enough for now?
