### PR TITLE
add assets:list to documents dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ function Bankai (entry, opts) {
   // Insert nodes into the graph.
   this.graph.node('assets', assetsNode)
   // this.graph.node('document', [ 'manifest:color', 'style:bundle', 'assets:favicons', 'script:bundle' ], documentNode)
-  this.graph.node('documents', [ 'manifest:color', 'style:bundle', 'scripts:bundle', 'reload:bundle' ], documentNode)
+  this.graph.node('documents', [ 'assets:list', 'manifest:color', 'style:bundle', 'scripts:bundle', 'reload:bundle' ], documentNode)
   this.graph.node('manifest', manifestNode)
   this.graph.node('scripts', scriptNode)
   this.graph.node('reload', reloadNode)


### PR DESCRIPTION
I was running into an issue when I had >300 items in the assets directory. 

`bankai` was failing because `state.assets.list.buffer` was not available when called by `extractFonts` in `graph-document.js`

This PR adds the `assets:list` event to the document node's dependencies. This ensures the `state.assets.list` is available when the documents node runs.
