### PR TITLE
pass ssr error in callback - ensures SSR will re-render after errors

### DIFF
--- a/lib/graph-document.js
+++ b/lib/graph-document.js
@@ -21,16 +21,14 @@ function node (state, createEdge) {
   var self = this
 
   serverRender(entry, function (err, render) {
-    if (err) {
+    if (err && err.isSsr) {
+      self.emit('ssr', {success: false, error: err})
+    } else if (err) {
       err = ttyError('documents', entry, err)
       return self.emit('error', 'documents', entry, err)
     }
 
-    if (render.ssrError) {
-      self.emit('ssr', {success: false, error: render.ssrError})
-    } else {
-      self.emit('ssr', {success: true})
-    }
+    self.emit('ssr', {success: true})
 
     var fonts = extractFonts(state.assets)
     var list = render.list

--- a/lib/server-render.js
+++ b/lib/server-render.js
@@ -19,6 +19,7 @@ function serverRender (entry, cb) {
   assert.equal(typeof entry, 'string')
 
   var app
+  var ssrError = null
   var channel = new EventEmitter()
   channel.once('list', function (list) {
     render.list = list
@@ -28,7 +29,10 @@ function serverRender (entry, cb) {
     app = proxyquire(entry, {})
   } catch (err) {
     var failedRequire = err.message === `Cannot find module '${entry}'`
-    if (!failedRequire) render.ssrError = err
+    if (!failedRequire) {
+      ssrError = err
+      ssrError.isSsr = true
+    }
     app = null
   }
 
@@ -66,7 +70,7 @@ function serverRender (entry, cb) {
     }
   }
 
-  cb(null, render)
+  cb(ssrError, render)
 
   function render (route, state) {
     var res


### PR DESCRIPTION
I noticed that SSR would never fire again after having an error. This is because the `ssrError` attribute hanging off of `render` was never cleared between runs, so the logic assumed every subsequent run was an error.

This PR updates the render function to pass the SSR error back in the callback instead of hanging it off of `render`. This ensures SSR works after errors are fixed in the app code and also ensures safety if multiple renders are firing at once for some reason as the attribute is not shared.
