### PR TITLE
Update documentify

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "css-extract": "^1.2.0",
     "debug": "^3.0.1",
     "disc": "^1.3.2",
-    "documentify": "^2.0.0",
+    "documentify": "^3.0.0",
     "exorcist": "^1.0.0",
     "explain-error": "^1.0.4",
     "factor-bundle": "^2.5.0",


### PR DESCRIPTION
this changes the order transforms are run in: those defined in
`package.json` are now run first, like in browserify. technically
that's a breaking change, but maybe we can merge this without bumping
bankai because it's still `-rc`? :P