### PR TITLE
Manually blow away cache when server rendering

### DIFF
--- a/lib/server-render.js
+++ b/lib/server-render.js
@@ -1,5 +1,4 @@
 var EventEmitter = require('events').EventEmitter
-var proxyquire = require('proxyquire')
 var assert = require('assert')
 
 var getAllRoutes = require('wayfarer/get-all-routes')
@@ -25,7 +24,7 @@ function serverRender (entry, cb) {
   })
 
   try {
-    app = proxyquire(entry, {})
+    app = freshRequire(entry)
   } catch (err) {
     var failedRequire = err.message === `Cannot find module '${entry}'`
     if (!failedRequire) render.ssrError = err
@@ -76,4 +75,24 @@ function serverRender (entry, cb) {
     channel.emit('req', route, state)
     return res
   }
+}
+
+function freshRequire (file) {
+  var backup = require.cache
+  require.cache = {}
+
+  // Native modules don't work when re-required, so we must keep the cached version.
+  var keepKeys = Object.keys(backup).filter(isNativeModulePath)
+  for (var i = 0; i < keepKeys.length; i++) {
+    require.cache[keepKeys[i]] = backup[keepKeys[i]]
+  }
+
+  var exports = require(file)
+
+  require.cache = backup
+  return exports
+}
+
+function isNativeModulePath (file) {
+  return /\.node$/.test(file)
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "pino": "^4.7.1",
     "pino-colada": "^1.4.2",
     "prettier-bytes": "^1.0.4",
-    "proxyquire": "^1.8.0",
     "pump": "^1.0.2",
     "pumpify": "^1.3.5",
     "purify-css": "^1.2.5",


### PR DESCRIPTION
Proxyquire normally only removes the required file from the cache, but
not its dependencies. It removes everything if you use proxyquire to
stub a global variable, but I think stubbing a variable would be a weird
thing for bankai to do :thinking:

This patch deletes the entire module cache before requiring the app
entry point. It keeps native modules cached because requiring those
twice doesn't work. At the end the cache is restored.

This should solve the issue where changes in non-entry modules were not
picked up by server rendering.

Most of the existing modules try to be very smart about what they delete
from the cache, but I think this should also work?