### PR TITLE
Recursively remove require and children from require.cache

### DIFF
--- a/lib/server-render.js
+++ b/lib/server-render.js
@@ -1,5 +1,4 @@
 var EventEmitter = require('events').EventEmitter
-var proxyquire = require('proxyquire')
 var assert = require('assert')
 
 var getAllRoutes = require('wayfarer/get-all-routes')
@@ -25,7 +24,7 @@ function serverRender (entry, cb) {
   })
 
   try {
-    app = proxyquire(entry, {})
+    app = freshRequire(entry)
   } catch (err) {
     var failedRequire = err.message === `Cannot find module '${entry}'`
     if (!failedRequire) render.ssrError = err
@@ -76,4 +75,24 @@ function serverRender (entry, cb) {
     channel.emit('req', route, state)
     return res
   }
+}
+
+function freshRequire (file) {
+  var backup = require.cache
+  require.cache = {}
+
+  // Native modules don't work when re-required, so we must keep the cached version.
+  var keepKeys = Object.keys(backup).filter(isNativeModulePath)
+  for (var i = 0; i < keepKeys.length; i++) {
+    require.cache[keepKeys[i]] = backup[keepKeys[i]]
+  }
+
+  var exports = require(file)
+
+  require.cache = backup
+  return exports
+}
+
+function isNativeModulePath (file) {
+  return /\.node$/.test(file)
 }

--- a/lib/server-render.js
+++ b/lib/server-render.js
@@ -1,5 +1,6 @@
 var EventEmitter = require('events').EventEmitter
 var assert = require('assert')
+var debug = require('debug')('bankai.server-render')
 
 var getAllRoutes = require('wayfarer/get-all-routes')
 
@@ -78,21 +79,30 @@ function serverRender (entry, cb) {
 }
 
 function freshRequire (file) {
-  var backup = require.cache
-  require.cache = {}
-
-  // Native modules don't work when re-required, so we must keep the cached version.
-  var keepKeys = Object.keys(backup).filter(isNativeModulePath)
-  for (var i = 0; i < keepKeys.length; i++) {
-    require.cache[keepKeys[i]] = backup[keepKeys[i]]
-  }
+  clearRequireAndChildren(file)
 
   var exports = require(file)
 
-  require.cache = backup
   return exports
 }
 
-function isNativeModulePath (file) {
-  return /\.node$/.test(file)
+function isNotNativeModulePath (file) {
+  return /\.node$/.test(file.id) === false
+}
+
+function isNotInNodeModules (file) {
+  return /node_modules/.test(file.id) === false
+}
+
+function clearRequireAndChildren (key) {
+  if (!require.cache[key]) return
+
+  require.cache[key].children
+    .filter(isNotNativeModulePath)
+    .filter(isNotInNodeModules)
+    .forEach(function (child) {
+      clearRequireAndChildren(child.id)
+    })
+  debug('clearing require cache for %s', key)
+  delete require.cache[key]
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "pino": "^4.7.1",
     "pino-colada": "^1.4.2",
     "prettier-bytes": "^1.0.4",
-    "proxyquire": "^1.8.0",
     "pump": "^1.0.2",
     "pumpify": "^1.3.5",
     "purify-css": "^1.2.5",


### PR DESCRIPTION
This is a riff on @goto-bus-stop's PR #303 

This seems to work better for me?

This also will not touch `node_modules` required files, but if folks think thats bad idea we can include them.
