### PR TITLE
reload on document change instead of script

### DIFF
--- a/http.js
+++ b/http.js
@@ -80,7 +80,7 @@ function start (entry, opts) {
     }
     state.files[nodeName] = data
 
-    if (name === 'scripts:bundle') emitter.emit('scripts:bundle', node)
+    if (name === 'documents:index.html') emitter.emit('documents:index.html', node)
     if (name === 'styles:bundle') emitter.emit('styles:bundle', node)
 
     // Only calculate the gzip size if there's a buffer. Apparently zipping
@@ -178,7 +178,7 @@ function start (entry, opts) {
 
   router.route(/\/reload/, function sse (req, res) {
     var connected = true
-    emitter.on('scripts:bundle', reloadScript)
+    emitter.on('documents:index.html', reloadScript)
     emitter.on('styles:bundle', reloadStyle)
     state.sse += 1
     if (!quiet) render()
@@ -202,7 +202,7 @@ function start (entry, opts) {
     function disconnect () {
       clearInterval(interval)
       if (connected) {
-        emitter.removeListener('scripts:bundle', reloadScript)
+        emitter.removeListener('documents:index.html', reloadScript)
         emitter.removeListener('styles:bundle', reloadStyle)
         connected = false
         state.sse -= 1


### PR DESCRIPTION
With the addition of the subresource integrity logic, we're seeing issues when running `bankai start`. When the bundle changes the page gets reloaded, but sometimes the document has not been yet been rebuilt with the new hash on the `<script>` tag. This causes a `subresource integrity error` to be thrown in browser and the script fails to load.

This PR changes `http.js` to only trigger a reload when the document has been fully rebuilt. This should avoid the race condition.

It feels a little bad not renaming everything to `reloadDocument` all the way down as it would be a bit more accurate... I'm happy to update this if this PR is going in the right direction!