### PR TITLE
pluralize style -> styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Pass in a filename and output a JS bundle.
 ### `compiler.assets(assetName, done(err, buffer))`
 Output any other file besides JS, CSS or HTML.
 
-### `compiler.style(done(err, buffer))`
+### `compiler.styles(name, done(err, buffer))`
 Output a CSS bundle.
 
 ### `compiler.manifest(done(err, buffer))`

--- a/http.js
+++ b/http.js
@@ -14,7 +14,7 @@ var files = [
   'documents',
   'scripts',
   'manifest',
-  'style',
+  'styles',
   'service-worker'
 ]
 
@@ -80,7 +80,7 @@ function start (entry, opts) {
     state.files[nodeName] = data
 
     if (name === 'scripts:bundle') emitter.emit('scripts:bundle', node)
-    if (name === 'style:bundle') emitter.emit('style:bundle', node)
+    if (name === 'styles:bundle') emitter.emit('styles:bundle', node)
 
     // Only calculate the gzip size if there's a buffer. Apparently zipping
     // an empty file means it'll pop out with a 20B base size.
@@ -128,8 +128,9 @@ function start (entry, opts) {
     })
   })
 
-  router.route(/\/bundle.css$/, function (req, res, params) {
-    compiler.style(function (err, node) {
+  router.route(/\/([a-zA-Z0-9-_]+)\.css$/, function (req, res, params) {
+    var name = params[1]
+    compiler.styles(name, function (err, node) {
       if (err) {
         res.statusCode = 404
         return res.end(err.message)

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function Bankai (entry, opts) {
     'assets',
     'service-worker',
     'scripts',
-    'style',
+    'styles',
     'documents'
   ]
 
@@ -65,9 +65,9 @@ function Bankai (entry, opts) {
     } else if (eventName === 'service-worker:bundle') {
       count['service-worker'] = 1
       queue['service-worker'].ready()
-    } else if (eventName === 'style:bundle') {
-      count['style'] = 1
-      queue['style'].ready()
+    } else if (eventName === 'styles:bundle') {
+      count['styles'] = 1
+      queue['styles'].ready()
     }
   })
 
@@ -90,13 +90,12 @@ function Bankai (entry, opts) {
 
   // Insert nodes into the graph.
   this.graph.node('assets', assetsNode)
-  // this.graph.node('document', [ 'manifest:color', 'style:bundle', 'assets:favicons', 'script:bundle' ], documentNode)
-  this.graph.node('documents', [ 'assets:list', 'manifest:color', 'manifest:description', 'style:bundle', 'scripts:bundle', 'reload:bundle' ], documentNode)
+  this.graph.node('documents', [ 'assets:list', 'manifest:color', 'manifest:description', 'styles:bundle', 'scripts:bundle', 'reload:bundle' ], documentNode)
   this.graph.node('manifest', manifestNode)
   this.graph.node('scripts', scriptNode)
   this.graph.node('reload', reloadNode)
-  this.graph.node('service-worker', [ 'assets:list', 'style:bundle', 'scripts:bundle', 'documents:list' ], serviceWorkerNode)
-  this.graph.node('style', [ 'scripts:style', 'scripts:bundle' ], styleNode)
+  this.graph.node('service-worker', [ 'assets:list', 'styles:bundle', 'scripts:bundle', 'documents:list' ], serviceWorkerNode)
+  this.graph.node('styles', [ 'scripts:style', 'scripts:bundle' ], styleNode)
 
   // Kick off the graph.
   this.graph.start({
@@ -136,14 +135,15 @@ Bankai.prototype.scripts = function (filename, cb) {
   })
 }
 
-Bankai.prototype.style = function (cb) {
+Bankai.prototype.styles = function (filename, cb) {
+  assert.equal(typeof filename, 'string')
   assert.equal(typeof cb, 'function')
-  var stepName = 'style'
-  var edgeName = 'bundle'
+  var stepName = 'styles'
+  var edgeName = filename.split('.')[0]
   var self = this
   this.queue[stepName].add(function () {
     var data = self.graph.data[stepName][edgeName]
-    if (!data) return cb(new Error('bankai.style: could not find bundle'))
+    if (!data) return cb(new Error('bankai.styles: could not find bundle'))
     cb(null, data)
   })
 }

--- a/lib/cmd-build.js
+++ b/lib/cmd-build.js
@@ -54,7 +54,7 @@ function build (entry, opts) {
     })
 
     compiler.manifest(writeSimple('manifest.json', 'manifest'))
-    compiler.style(writeSingle('bundle.css', 'style'))
+    compiler.styles('bundle.css', writeSingle('bundle.css', 'styles'))
     compiler.scripts('bundle.js', writeSingle('bundle.js', 'scripts'))
 
     function writeAssets (step) {

--- a/lib/graph-document.js
+++ b/lib/graph-document.js
@@ -50,7 +50,7 @@ function node (state, createEdge) {
       d.transform(viewportTransform)
       d.transform(polyfillTransform)
       d.transform(scriptTransform, { hash: state.scripts.bundle.hash })
-      d.transform(styleTransform, { hash: state.style.bundle.hash })
+      d.transform(styleTransform, { hash: state.styles.bundle.hash })
       d.transform(preloadTransform)
       d.transform(loadFontsTransform, { fonts: fonts })
       d.transform(manifestTransform)
@@ -62,8 +62,8 @@ function node (state, createEdge) {
       // TODO: apple touch icons
       // TODO: favicons
 
-      if (state.style.bundle.buffer.length) {
-        d.transform(criticalTransform, { css: state.style.bundle.buffer })
+      if (state.styles.bundle.buffer.length) {
+        d.transform(criticalTransform, { css: state.styles.bundle.buffer })
       }
 
       if (state.metadata.reload) {

--- a/lib/graph-service-worker.js
+++ b/lib/graph-service-worker.js
@@ -116,7 +116,7 @@ function fileEnv (state) {
     'https://cdn.polyfill.io/v2/polyfill.min.js',
     `${state.scripts.bundle.hash.toString('hex').slice(0, 16)}/bundle.js`
   ]
-  var style = [`${state.style.bundle.hash.toString('hex').slice(0, 16)}/bundle.css`]
+  var style = [`${state.styles.bundle.hash.toString('hex').slice(0, 16)}/bundle.css`]
   var assets = split(state.assets.list.buffer)
   var doc = split(state.documents.list.buffer)
   var manifest = ['/manifest.json']

--- a/lib/graph-style.js
+++ b/lib/graph-style.js
@@ -19,13 +19,13 @@ function node (state, createEdge) {
   try {
     bundle = purify(script, style, { minify: true })
   } catch (e) {
-    this.emit('error', 'style', 'purify-css', e)
+    this.emit('error', 'styles', 'purify-css', e)
   }
 
   try {
     bundle = clean.minify(bundle).styles
   } catch (e) {
-    this.emit('error', 'style', 'clean-css', e)
+    this.emit('error', 'styles', 'clean-css', e)
   }
 
   createEdge('bundle', Buffer.from(bundle))

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -15,7 +15,7 @@ var files = [
   'assets',
   'documents',
   'scripts',
-  'style',
+  'styles',
   'manifest',
   'service-worker'
 ]

--- a/test/document.js
+++ b/test/document.js
@@ -54,7 +54,7 @@ tape('renders some HTML', function (assert) {
     expected = expected.replace('__SCRIPTS_HASH__', res.hash.toString('hex').slice(0, 16))
     expected = expected.replace('__SCRIPTS_INTEGRITY__', res.hash.toString('base64'))
 
-    compiler.style(function (err, res) {
+    compiler.styles('bundle.css', function (err, res) {
       assert.ifError(err, 'no err bundling style')
       expected = expected.replace('__STYLE_HASH__', res.hash.toString('hex').slice(0, 16))
       expected = expected.replace('__STYLE_INTEGRITY__', res.hash.toString('base64'))
@@ -116,7 +116,7 @@ tape('server render choo apps', function (assert) {
     assert.ifError(err, 'no err bundling scripts')
     expected = expected.replace('__SCRIPTS_HASH__', res.hash.toString('hex').slice(0, 16))
     expected = expected.replace('__SCRIPTS_INTEGRITY__', res.hash.toString('base64'))
-    compiler.style(function (err, res) {
+    compiler.styles('bundle.css', function (err, res) {
       assert.ifError(err, 'no err bundling style')
       assert.ifError(err)
       expected = expected.replace('__STYLE_HASH__', res.hash.toString('hex').slice(0, 16))

--- a/test/style.js
+++ b/test/style.js
@@ -27,7 +27,7 @@ tape('extract style from script', function (assert) {
   fs.writeFileSync(tmpScriptname, script)
 
   var compiler = bankai(tmpScriptname, { watch: false })
-  compiler.style(function (err, res) {
+  compiler.styles('bundle.css', function (err, res) {
     assert.error(err, 'no error writing style')
     assert.equal(res.buffer.toString(), expected, 'res was equal')
     rimraf.sync(tmpDirname)
@@ -59,7 +59,7 @@ tape('remove unused styles', function (assert) {
   fs.writeFileSync(tmpScriptname, script)
 
   var compiler = bankai(tmpScriptname, { watch: false })
-  compiler.style(function (err, res) {
+  compiler.styles('bundle.css', function (err, res) {
     assert.error(err, 'no error writing style')
     assert.equal(res.buffer.toString(), expected, 'res was equal')
     rimraf.sync(tmpDirname)


### PR DESCRIPTION
Final breaking change for the API. Changes `.style()` to `.style()`. Allows us to experiment in the future with splitting CSS bundles, and the like. Not sure what the approach would be, but allows for this to happen without breaking the API. Thanks!