### PR TITLE
watch fixes

### DIFF
--- a/lib/graph-service-worker.js
+++ b/lib/graph-service-worker.js
@@ -29,6 +29,7 @@ function node (state, createEdge) {
   var basedir = utils.dirname(state.metadata.entry)
 
   if (state.metadata.watch && !state.metadata.watchers.serviceWorker) {
+    state.metadata.watchers.serviceWorker = true
     debug('watching ' + basedir + ' for ' + filenames.join(', '))
     unwatch = utils.watch(basedir, filenames, parse)
     this.on('close', function () {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -28,8 +28,9 @@ exports.basefile = function (pathname) {
 exports.watch = function (dirname, filenames, cb) {
   var debug = Debug('bankai.utils.watch')
   return recursiveWatch(dirname, function (filename) {
+    debug('watching files %s in %s', filenames, dirname)
     if (filenames.indexOf(path.relative(dirname, filename)) !== -1) {
-      debug(filename + ' changed')
+      debug('%s changed', filename)
       cb(filename)
     }
   })
@@ -39,9 +40,10 @@ exports.watch = function (dirname, filenames, cb) {
 // Does nothing if we're already watching.
 exports.watchDirs = function (basedir, dirnames, cb) {
   var debug = Debug('bankai.utils.watchDir')
+  debug('watching directories %s in %s', dirnames, basedir)
 
   var regexes = dirnames.map(function (dirname) {
-    var relative = path.relative(basedir, dirname)
+    var relative = path.join(basedir, dirname)
     return new RegExp('^' + relative)
   })
 
@@ -51,7 +53,7 @@ exports.watchDirs = function (basedir, dirnames, cb) {
     })
 
     if (changed) {
-      debug(filename + ' changed')
+      debug('%s changed', filename)
       cb(filename)
     }
   })


### PR DESCRIPTION
I think I found a source for "warning: possible EventEmitter memory leak detected" messages. It looks like a watcher in `graph-service-worker.js` was being added every reload.

Also, I noticed that `watchDirs` regexes were we being generated as `^assets` instead of the full absolute path `^/Users/flet/code/stuff/assets`.

I also added some additional debug un `utils` and updated it to use `debug`s formatters to avoid unnecessary string concats if debug is off.
