### PR TITLE
remove polyfill from README and service worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,6 @@ can be useful to know which optimizations we apply. This is a list:
 - __cleanCSS:__ minify the bundle.
 
 ### HTML
-- __polyfill:__ preloads [polyfill.io](http://polyfill.io/), the zero overhead
-  polyfilling service.
 - __inline-critical-css:__ extract all crititical CSS for a page into the
   `<head>` of the document. This means that every page will be able to render
   after the first roundtrip, which makes for super snappy pages.

--- a/lib/graph-service-worker.js
+++ b/lib/graph-service-worker.js
@@ -113,7 +113,6 @@ function find (rootname, arr, done) {
 
 function fileEnv (state) {
   var script = [
-    'https://cdn.polyfill.io/v2/polyfill.min.js',
     `${state.scripts.bundle.hash.toString('hex').slice(0, 16)}/bundle.js`
   ]
   var style = [`${state.styles.bundle.hash.toString('hex').slice(0, 16)}/bundle.css`]


### PR DESCRIPTION
Oops, sorry @yoshuawuyts I may have merged #323 too quick!

This PR removes polyfill references from the README and `graph-service-worker.js`