### PR TITLE
Listen for 'close' to avoid ERR_HTTP2_STREAM_CLOSED errors

### DIFF
--- a/http.js
+++ b/http.js
@@ -194,7 +194,7 @@ function start (entry, opts) {
     }, 4000)
 
     req.on('error', disconnect)
-    res.on('error', disconnect)
+    res.on('close', disconnect)
     res.on('finish', disconnect)
 
     function disconnect () {


### PR DESCRIPTION
When running `9.0.0-rc9` locally `ERR_HTTP2_STREAM_CLOSED` is often thrown when reloading a route at an irregular interval. Node 8 emits a 'close' event when we request a steam abort. This fix appears to work locally for me when npm linking bankai into a consuming application.

```
> bankai start index.js

A critical error occured, forcing Bankai to abort:

Error [ERR_HTTP2_STREAM_CLOSED]: The stream is already closed
    at Http2ServerResponse.write (internal/http2/compat.js:563:19)
    at Timeout._onTimeout (/Users/elliott.crush/sites/choo-app/node_modules/bankai/http.js:191:11)
    at ontimeout (timers.js:475:11)
    at tryOnTimeout (timers.js:310:5)
    at Timer.listOnTimeout (timers.js:270:5)

If you think this might be a bug in Bankai, please consider helping
improve Bankai's stability by submitting an error to:

  https://github.com/choojs/bankai/issues/new

Please include the steps to reproduce this error, the stack trace
printed above, your version of Node, and your version of npm. Thanks!
```