### PR TITLE
set content-type via MIME type of asset name

### DIFF
--- a/http.js
+++ b/http.js
@@ -1,5 +1,6 @@
 var EventEmitter = require('events').EventEmitter
 var gzipMaybe = require('http-gzip-maybe')
+var mime = require('mime/lite')
 var gzipSize = require('gzip-size')
 var assert = require('assert')
 var path = require('path')
@@ -171,6 +172,7 @@ function start (entry, opts) {
         res.statusCode = 404
         return res.end(err.message)
       }
+      res.setHeader('content-type', mime.getType(name))
       res.end(node.buffer)
     })
   })

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "inline-critical-css": "^1.1.0",
     "json-stream-to-object": "^1.1.0",
     "keypress": "^0.2.1",
+    "mime": "^2.0.3",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "nanologger": "^1.3.1",


### PR DESCRIPTION
I was running into issues when trying to serve .svg files from /assets in bankai. It turns out that the content-type was not set correctly.

This PR adds the [`mime` package](https://github.com/broofa/node-mime) (~2.8KB) and uses it to determine what content-type to set based on the file name.