### PR TITLE
Update yo-yoify

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "concat-stream": "^1.6.0",
     "convert-source-map": "^1.5.0",
     "css-extract": "^1.2.0",
-    "dedent": "^0.7.0",
     "debug": "^3.0.1",
+    "dedent": "^0.7.0",
     "disc": "^1.3.2",
     "documentify": "^3.0.0",
     "exorcist": "^1.0.0",
@@ -73,7 +73,7 @@
     "watchify": "^3.9.0",
     "wayfarer": "^6.6.2",
     "xtend": "^4.0.1",
-    "yo-yoify": "^3.7.3"
+    "yo-yoify": "^4.1.0"
   },
   "devDependencies": {
     "assert-html": "^1.1.4",


### PR DESCRIPTION
changes:
- removes support for onload.
- adds support for `<div ${object} />` splat properties.
- generates smaller bundles for choo by removing `choo/html` requires.
- compiles babelified template strings too