### PR TITLE
allow curl from CLI

### DIFF
--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -18,7 +18,7 @@ var KEY_LOCATION = path.join(CONFIG_DIR, KEY_NAME)
 
 exports.createServer = createDevServer
 
-function createDevServer (http2Handler) {
+function createDevServer (connectionHandler) {
   var httpPort, httpsPort
   var createSecureServer
 
@@ -59,7 +59,7 @@ function createDevServer (http2Handler) {
 
           httpsPort = port
           var serverOpts = { cert, key, allowHTTP1: true }
-          var http2Server = createSecureServer(serverOpts, http2Handler)
+          var http2Server = createSecureServer(serverOpts, connectionHandler)
           http2Server.keepAliveTimeout = 0
           http2Server.timeout = 0
           http2Server.listen(httpsPort, function () {
@@ -85,10 +85,17 @@ function createDevServer (http2Handler) {
 
   function httpConnection (req, res) {
     var host = req.headers['host']
-    res.writeHead(301, {
-      location: 'https://' + host + req.url
-    })
-    res.end()
+    var location = 'https://' + host + req.url
+    var agent = req.headers['user-agent']
+
+    // We want to force HTTPS connections, but using curl(1) or wget(1) from
+    // the command line can be convenient to quickly check output.
+    if (/^(curl|wget)/i.test(agent)) {
+      return connectionHandler(req, res)
+    } else {
+      res.writeHead(301, { location: location })
+      res.end(`Redirecting to ${location}`)
+    }
   }
 }
 


### PR DESCRIPTION
Allows using `curl(1)` from the command line to quickly test output. Only available on the command line, so no security issues here (I mean; we're self-signing certs here, so you don't wanna run it in prod anyway).

Also added a default body for the `301` redirect, so folks will have a better time if they ever hit it. Thanks!