### PR TITLE
fix brfs

### DIFF
--- a/lib/graph-script.js
+++ b/lib/graph-script.js
@@ -37,8 +37,8 @@ function node (state, createEdge) {
 
   b.ignore('sheetify/insert')
   b.transform(sheetify)
-  b.transform(brfs)
   b.transform(glslify)
+  b.transform(brfs, { global: true })
   b.transform(yoyoify, { global: true })
 
   if (!fullPaths) b.plugin(cssExtract, { out: bundleStyles })


### PR DESCRIPTION
Fixes the parsing issue Bankai was having https://github.com/choojs/bankai/issues/329! — e.g. allows `babel` to run from the `package.json`. Unfortunately it can't quite run as a global transform, but that's a separate issue. Thanks!

P.s. We should still perform the patches as mentioned in https://github.com/choojs/bankai/issues/329#issuecomment-344269383.