### PR TITLE
babel: set useBuiltIns to true

### DIFF
--- a/lib/graph-script.js
+++ b/lib/graph-script.js
@@ -56,6 +56,7 @@ function node (state, createEdge) {
     global: true,
     presets: [
       [babelPresetEnv, {
+        useBuiltIns: true,
         targets: { browsers: browsers }
       }]
     ]


### PR DESCRIPTION
Henry Zhu rightfully pointed out [on Twitter](https://twitter.com/left_pad/status/933509281005129728) that we weren't setting `useBuiltIns` on the `babelPresetEnv` plugin.

This is supposed to fix the issues we were having, where extra polyfills were being included, but isn't quite working. If we replace `index.js` with the following:
```js
require('babel-polyfill')
```
We should be getting a result of 0 bytes, because nothing is used. Instead, if we curl we get:
```sh
$ curl -s localhost:8080/bundle.js | wc -c | pretty-bytes
206 kB
```
Not entirely sure what might be preventing Babel from pruning unused dependencies here 😢 