### PR TITLE
Ignore .babelrc files in babelify

### DIFF
--- a/lib/graph-script.js
+++ b/lib/graph-script.js
@@ -54,6 +54,7 @@ function node (state, createEdge) {
   b.transform(glslify)
   b.transform(babelify, {
     global: true,
+    babelrc: false,
     presets: [
       [babelPresetEnv, {
         targets: { browsers: browsers }


### PR DESCRIPTION
The goal is to ignore `.babelrc` files in `node_modules` per @goto-bus-stop's [comment](https://github.com/choojs/bankai/issues/341#issuecomment-346684897) in [#341](https://github.com/choojs/bankai/issues/341) to solve the issue raised there.