### PR TITLE
Enable tinyify in `bankai inspect`

### DIFF
--- a/lib/graph-script.js
+++ b/lib/graph-script.js
@@ -45,7 +45,7 @@ function node (state, createEdge) {
   var entry = state.metadata.entry
   var fullPaths = Boolean(state.metadata.fullPaths)
   var b = browserify(browserifyOpts([entry], fullPaths))
-  var shouldMinify = !state.metadata.watch && !fullPaths
+  var shouldMinify = !state.metadata.watch
 
   if (state.metadata.watch) {
     b = watchify(b)

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "strip-ansi": "^4.0.0",
     "tfilter": "^1.0.1",
     "through2": "^2.0.3",
-    "tinyify": "^2.3.0",
+    "tinyify": "^2.4.0",
     "v8-compile-cache": "^1.1.0",
     "watchify": "^3.9.0",
     "wayfarer": "^6.6.2",


### PR DESCRIPTION
tinyify 2.4.0 detects the browserify `fullPaths` option and produces a
bundle that `disc` can use.