### PR TITLE
Leverage v8 cache

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -2,6 +2,8 @@
 
 process.title = 'bankai'
 
+require('v8-compile-cache')
+
 var ansi = require('ansi-escape-sequences')
 var minimist = require('minimist')
 var dedent = require('dedent')

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "strip-ansi": "^4.0.0",
     "through2": "^2.0.3",
     "tinyify": "^2.3.0",
+    "v8-compile-cache": "^1.1.0",
     "watchify": "^3.9.0",
     "wayfarer": "^6.6.2",
     "yo-yoify": "^4.1.0"


### PR DESCRIPTION
This seems to shave 500ms - 1s from a bankai build run.

Taken from: https://twitter.com/samccone/status/938418097895063553

We should probably investigate the Parcel source code more to find optimization
pathways. Would be fun to speed things up even further.

Oh by the way, still on vacation. So not going to check replies until the 14th;
if this looks good, feel free to merge + release before then. Thanks!