### PR TITLE
Ignore .babelrc files of dependencies.

### DIFF
--- a/lib/graph-script.js
+++ b/lib/graph-script.js
@@ -1,6 +1,7 @@
 var debug = require('debug')('bankai.node-script')
 var concat = require('concat-stream')
 var to = require('flush-write-stream')
+var tfilter = require('tfilter')
 var assert = require('assert')
 
 var babelPresetEnv = require('babel-preset-env')
@@ -25,6 +26,12 @@ var browsers = [
   'last 2 Safari versions',
   'last 2 Edge versions',
   '> 1%' // Cover all other browsers that are widely used.
+]
+
+var babelPresets = [
+  [babelPresetEnv, {
+    targets: { browsers: browsers }
+  }]
 ]
 
 module.exports = node
@@ -52,13 +59,17 @@ function node (state, createEdge) {
   b.ignore('sheetify/insert')
   b.transform(sheetify)
   b.transform(glslify)
-  b.transform(babelify, {
+  // Dependencies should be transformed, but their .babelrc should be ignored.
+  b.transform(tfilter(babelify, { include: /node_modules/ }), {
     global: true,
-    presets: [
-      [babelPresetEnv, {
-        targets: { browsers: browsers }
-      }]
-    ]
+    babelrc: false,
+    presets: babelPresets
+  })
+  // In our own code, .babelrc files should be used.
+  b.transform(tfilter(babelify, { exclude: /node_modules/ }), {
+    global: true,
+    babelrc: true,
+    presets: babelPresets
   })
   b.transform(brfs, { global: true })
   b.transform(yoyoify, { global: true })

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "split-require": "^2.0.0",
     "split2": "^2.1.1",
     "strip-ansi": "^4.0.0",
+    "tfilter": "^1.0.1",
     "through2": "^2.0.3",
     "tinyify": "^2.3.0",
     "watchify": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "yo-yoify": "^4.1.0"
   },
   "devDependencies": {
+    "a-module-with-babelrc": "^1.0.0",
     "assert-html": "^1.1.4",
     "choo": "^6.0.0",
     "choo-devtools": "^2.0.0",


### PR DESCRIPTION
One attempt at fixing the issue described in #348: Some npm packages don't exclude `.babelrc` from the package, which causes babel to try to transform the package's files with their custom babel config. but, usually packages don't specify babel transforms as production deps, so that doesn't work.

this patch uses [tfilter](https://npmjs.com/package/tfilter) to apply different babelify options for different files. namely, files in node_modules are transformed with babel-preset-env _only_, ignoring their own .babelrc configs. local files are transformed with babel-preset-env by default but local .babelrc config is merged in so folks can add their own babel plugins too (this is the default babelify behaviour).

the babelify config for local files only also gets the `global: true` option, but that's only to make sure that the order stays the same as it was before (so it runs _after_ yoyoify etc). i think it might be best to change that in the future, so that babelify runs earlier, but it could be a breaking change so i held off on that for now.

 - [x] todo add a test for a dependency with a .babelrc file?