### PR TITLE
fix scripts build if empty server split

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ Bankai.prototype.scripts = function (filename, cb) {
   var self = this
   this.queue[stepName].add(function () {
     var data = self.graph.data[stepName][edgeName]
-    if (!data) return cb(new Error('bankai.scripts: could not find a bundle for ' + filename))
+    if (!data) return cb(new Error(`bankai.scripts: could not find a bundle for "${filename}"`))
     cb(null, data)
   })
 }

--- a/lib/cmd-build.js
+++ b/lib/cmd-build.js
@@ -98,7 +98,8 @@ function build (entry, opts) {
 
     function writeScripts (step) {
       var node = compiler.graph.data[step].list
-      var list = String(node.buffer).split(',')
+      var list = String(node.buffer)
+      list = list.length ? list.split(',') : []
       async.mapLimit(list, 3, iterator, function (err) {
         if (err) return log.error(err)
         completed(step)


### PR DESCRIPTION
Fix empty line output on build. Was trying to build `''` if no split bundles are passed, which throws an error. This works around that. Thanks!