### PR TITLE
Compare asset creation date on build

### DIFF
--- a/lib/cmd-build.js
+++ b/lib/cmd-build.js
@@ -1,6 +1,7 @@
 var ansi = require('ansi-escape-sequences')
 var pinoColada = require('pino-colada')
 var async = require('async-collection')
+var fsCompare = require('fs-compare')
 var pumpify = require('pumpify')
 var iltorb = require('iltorb')
 var mkdirp = require('mkdirp')
@@ -85,8 +86,13 @@ function build (entry, opts) {
         // on some OSes it is zero-copy all the way; e.g. never leaves the
         // kernel! :D
         function copy (done) {
-          if (fs.copyFile) fs.copyFile(src, dest, fin)
-          else pump(fs.createReadStream(src), fs.createWriteStream(dest), fin)
+          fsCompare.ctime(src, dest, function (err, diff) {
+            if (err) return done(err)
+            if (diff === 1) {
+              if (fs.copyFile) fs.copyFile(src, dest, fin)
+              else pump(fs.createReadStream(src), fs.createWriteStream(dest), fin)
+            }
+          })
           function fin (err) {
             if (err) return done(err)
             created(basedir, src)

--- a/lib/cmd-build.js
+++ b/lib/cmd-build.js
@@ -86,8 +86,9 @@ function build (entry, opts) {
         // on some OSes it is zero-copy all the way; e.g. never leaves the
         // kernel! :D
         function copy (done) {
-          fsCompare.ctime(src, dest, function (err, diff) {
+          fsCompare.mtime(src, dest, function (err, diff) {
             if (err) return done(err)
+            console.log('DIFF', diff)
             if (diff === 1) {
               if (fs.copyFile) fs.copyFile(src, dest, fin)
               else pump(fs.createReadStream(src), fs.createWriteStream(dest), fin)

--- a/lib/cmd-build.js
+++ b/lib/cmd-build.js
@@ -88,7 +88,6 @@ function build (entry, opts) {
         function copy (done) {
           fsCompare.mtime(src, dest, function (err, diff) {
             if (err) return done(err)
-            console.log('DIFF', diff)
             if (diff === 1) {
               if (fs.copyFile) fs.copyFile(src, dest, fin)
               else pump(fs.createReadStream(src), fs.createWriteStream(dest), fin)

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "fast-json-parse": "^1.0.2",
     "findup": "^0.1.5",
     "flush-write-stream": "^1.0.2",
+    "fs-compare": "0.0.4",
     "getport": "^0.1.0",
     "glslify": "^6.1.0",
     "gzip-size": "^3.0.0",


### PR DESCRIPTION
We should only copy assets when they are newer than what is already in `dist/`! Uses [fs-compare](https://github.com/jdeal/fs-compare).

This is especially handy when you have a Dat archive in your `dist/` directory and you don’t want to pollute the file history with new versions of assets every time you build. This is especially true if those assets are 500mb of videos, like in my case right now!