### PR TITLE
Tweak generated SSL key to make Chrome happy

### DIFF
--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -133,7 +133,18 @@ function createKeys (cb) {
 
       var opts = {
         days: 2048,
-        algorithm: 'sha256'
+        algorithm: 'sha256',
+        extensions: [
+          {
+            name: 'subjectAltName',
+            altNames: [
+              {
+                type: 2,
+                value: 'localhost'
+              }
+            ]
+          }
+        ]
       }
 
       selfsigned.generate([{ name: 'commonName', value: 'localhost' }], opts, function (err, keys) {

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -139,7 +139,7 @@ function createKeys (cb) {
             name: 'subjectAltName',
             altNames: [
               {
-                type: 2,
+                type: 2, // DNSName
                 value: 'localhost'
               }
             ]


### PR DESCRIPTION
The version of chrome on my machine (63) requires that the
subjectAltName field of the certificate be the same as the
hostname or it won't accept the certificate regardless of
whether it is "trusted" by the system.

Also, on MacOS users can run 

```
sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ~/.config/bankai/cert.pem
```

to add the certificate to their system keychain and then it will "just work" in all the browsers. Might be worth mentioning in the docs. 

