### PR TITLE
Save sourcemaps on `bankai build`

### DIFF
--- a/lib/cmd-build.js
+++ b/lib/cmd-build.js
@@ -164,10 +164,18 @@ function build (entry, opts) {
         var dirname = path.join(outdir, node.hash.toString('hex').slice(0, 16))
         mkdirp(dirname, function (err) {
           if (err) return log.error(err)
+          var sourcemapNode = type === 'scripts' && compiler.graph.data[type][`${filename}.map`]
+          var sourcemap = path.join(dirname, `${filename}.map`)
           filename = path.join(dirname, filename)
           writeCompressed(filename, node.buffer, function (err) {
             if (err) return log.error(err)
-            completed(type)
+            if (!sourcemapNode) {
+              return completed(type)
+            }
+            writeCompressed(sourcemap, sourcemapNode.buffer, function (err) {
+              if (err) return log.error(err)
+              completed(type)
+            })
           })
         })
       }


### PR DESCRIPTION
Fix #205: save sourcemaps content when building bundle.

@yoshuawuyts I'm not really sure about the implementation here, especially because there's no test on cmd-build.js

If you think the approach is correct, I'll add some.