### PR TITLE
Collapse hyperstream

### DIFF
--- a/lib/graph-document.js
+++ b/lib/graph-document.js
@@ -68,15 +68,15 @@ function node (state, createEdge) {
       var html = head(body, language)
       var d = documentify(entry, html)
       var header = [
-        viewportTransform(),
-        scriptTransform({ hash: state.scripts.bundle.hash }),
-        styleTransform({ hash: state.styles.bundle.hash }),
-        preloadTransform(),
-        loadFontsTransform({ fonts: fonts }),
-        manifestTransform(),
-        descriptionTransform({ description: String(state.manifest.description.buffer) }),
-        themeColorTransform({ color: String(state.manifest.color.buffer) }),
-        titleTransform({ title: title })
+        viewportTag(),
+        scriptTag({ hash: state.scripts.bundle.hash }),
+        styleTag({ hash: state.styles.bundle.hash }),
+        preloadTag(),
+        loadFontsTag({ fonts: fonts }),
+        manifestTag(),
+        descriptionTag({ description: String(state.manifest.description.buffer) }),
+        themeColorTag({ color: String(state.manifest.color.buffer) }),
+        titleTag({ title: title })
       ]
       // TODO: twitter
       // TODO: facebook
@@ -84,7 +84,7 @@ function node (state, createEdge) {
       // TODO: favicons
 
       if (state.metadata.reload) {
-        header.push(reloadTransform({ bundle: state.reload.bundle.buffer }))
+        header.push(reloadTag({ bundle: state.reload.bundle.buffer }))
       }
 
       d.transform(addToHead, header.join(''))
@@ -108,84 +108,75 @@ function head (body, lang) {
 }
 
 // Make sure that rel=preload works in Safari.
-function preloadTransform () {
+function preloadTag () {
   var content = ';(function(a){"use strict";var b=function(b,c,d){function e(a){return h.body?a():void setTimeout(function(){e(a)})}function f(){i.addEventListener&&i.removeEventListener("load",f),i.media=d||"all"}var g,h=a.document,i=h.createElement("link");if(c)g=c;else{var j=(h.body||h.getElementsByTagName("head")[0]).childNodes;g=j[j.length-1]}var k=h.styleSheets;i.rel="stylesheet",i.href=b,i.media="only x",e(function(){g.parentNode.insertBefore(i,c?g:g.nextSibling)});var l=function(a){for(var b=i.href,c=k.length;c--;)if(k[c].href===b)return a();setTimeout(function(){l(a)})};return i.addEventListener&&i.addEventListener("load",f),i.onloadcssdefined=l,l(f),i};"undefined"!=typeof exports?exports.loadCSS=b:a.loadCSS=b})("undefined"!=typeof global?global:this);'
   content += ';(function(a){if(a.loadCSS){var b=loadCSS.relpreload={};if(b.support=function(){try{return a.document.createElement("link").relList.supports("preload")}catch(b){return!1}},b.poly=function(){for(var b=a.document.getElementsByTagName("link"),c=0;c<b.length;c++){var d=b[c];"preload"===d.rel&&"style"===d.getAttribute("as")&&(a.loadCSS(d.href,d,d.getAttribute("media")),d.rel=null)}},!b.support()){b.poly();var c=a.setInterval(b.poly,300);a.addEventListener&&a.addEventListener("load",function(){b.poly(),a.clearInterval(c)}),a.attachEvent&&a.attachEvent("onload",function(){a.clearInterval(c)})}}})(this);'
   return `<script>${content}</script>`
 }
 
-function scriptTransform (opts) {
+function scriptTag (opts) {
   var hex = opts.hash.toString('hex').slice(0, 16)
   var base64 = 'sha512-' + opts.hash.base64Slice()
   var link = `/${hex}/bundle.js`
-  var header = `<script src="${link}" defer integrity="${base64}"></script>`
-  return header
+  return `<script src="${link}" defer integrity="${base64}"></script>`
 }
 
 // NOTE: in theory we should be able to add integrity checks to stylesheets too,
 // but in practice it turns out that it conflicts with preloading. So it's best
 // to disable it for now. See:
 // https://twitter.com/yoshuawuyts/status/920794607314759681
-function styleTransform (opts) {
+function styleTag (opts) {
   var hex = opts.hash.toString('hex').slice(0, 16)
   var link = `/${hex}/bundle.css`
-  var header = `<link rel="preload" as="style" href="${link}" onload="this.rel='stylesheet'">`
-  return header
+  return `<link rel="preload" as="style" href="${link}" onload="this.rel='stylesheet'">`
 }
 
-function loadFontsTransform (opts) {
-  var header = opts.fonts.reduce(function (header, font) {
+function loadFontsTag (opts) {
+  return opts.fonts.reduce(function (html, font) {
     if (!path.isAbsolute(font)) font = '/' + font
-    return header + `<link rel="preload" as="font" crossorigin href="${font}">`
+    return html + `<link rel="preload" as="font" crossorigin href="${font}">`
   }, '')
-  return header
 }
 
-function manifestTransform () {
-  var header = `
-  <link rel="manifest" href="/manifest.json">
+function manifestTag () {
+  return `
+    <link rel="manifest" href="/manifest.json">
   `.replace(/\n +/g, '')
-  return header
 }
 
-function viewportTransform () {
-  var header = `
+function viewportTag () {
+  return `
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
   `.replace(/\n +/g, '')
-  return header
 }
 
-function descriptionTransform (opts) {
-  var header = `
+function descriptionTag (opts) {
+  return `
     <meta name="description" content="${opts.description}">
   `.replace(/\n +/g, '')
-  return header
 }
 
-function themeColorTransform (opts) {
-  var header = `
+function themeColorTag (opts) {
+  return `
     <meta name="theme-color" content=${opts.color}>
   `.replace(/\n +/g, '')
-  return header
 }
 
-function titleTransform (opts) {
-  var header = `
+function titleTag (opts) {
+  return `
     <title>${opts.title}</title>
   `.replace(/\n +/g, '')
-  return header
 }
 
 function criticalTransform (opts) {
   return critical(String(opts.css))
 }
 
-function reloadTransform (opts) {
+function reloadTag (opts) {
   var bundle = opts.bundle
   var base64 = sha512(bundle)
-  var header = `<script integrity="${base64}">${bundle}</script>`
-  return header
+  return `<script integrity="${base64}">${bundle}</script>`
 }
 
 function addToHead (str) {

--- a/lib/graph-document.js
+++ b/lib/graph-document.js
@@ -67,26 +67,30 @@ function node (state, createEdge) {
 
       var html = head(body, language)
       var d = documentify(entry, html)
-      d.transform(viewportTransform)
-      d.transform(scriptTransform, { hash: state.scripts.bundle.hash })
-      d.transform(styleTransform, { hash: state.styles.bundle.hash })
-      d.transform(preloadTransform)
-      d.transform(loadFontsTransform, { fonts: fonts })
-      d.transform(manifestTransform)
-      d.transform(descriptionTransform, { description: String(state.manifest.description.buffer) })
-      d.transform(themeColorTransform, { color: String(state.manifest.color.buffer) })
-      d.transform(titleTransform, { title: title })
+      var header = [
+        viewportTransform(),
+        scriptTransform({ hash: state.scripts.bundle.hash }),
+        styleTransform({ hash: state.styles.bundle.hash }),
+        preloadTransform(),
+        loadFontsTransform({ fonts: fonts }),
+        manifestTransform(),
+        descriptionTransform({ description: String(state.manifest.description.buffer) }),
+        themeColorTransform({ color: String(state.manifest.color.buffer) }),
+        titleTransform({ title: title })
+      ]
       // TODO: twitter
       // TODO: facebook
       // TODO: apple touch icons
       // TODO: favicons
 
-      if (state.styles.bundle.buffer.length) {
-        d.transform(criticalTransform, { css: state.styles.bundle.buffer })
+      if (state.metadata.reload) {
+        header.push(reloadTransform({ bundle: state.reload.bundle.buffer }))
       }
 
-      if (state.metadata.reload) {
-        d.transform(reloadTransform, { bundle: state.reload.bundle.buffer })
+      d.transform(addToHead, header.join(''))
+
+      if (state.styles.bundle.buffer.length) {
+        d.transform(criticalTransform, { css: state.styles.bundle.buffer })
       }
 
       function complete (buf) { done(null, buf) }
@@ -107,8 +111,7 @@ function head (body, lang) {
 function preloadTransform () {
   var content = ';(function(a){"use strict";var b=function(b,c,d){function e(a){return h.body?a():void setTimeout(function(){e(a)})}function f(){i.addEventListener&&i.removeEventListener("load",f),i.media=d||"all"}var g,h=a.document,i=h.createElement("link");if(c)g=c;else{var j=(h.body||h.getElementsByTagName("head")[0]).childNodes;g=j[j.length-1]}var k=h.styleSheets;i.rel="stylesheet",i.href=b,i.media="only x",e(function(){g.parentNode.insertBefore(i,c?g:g.nextSibling)});var l=function(a){for(var b=i.href,c=k.length;c--;)if(k[c].href===b)return a();setTimeout(function(){l(a)})};return i.addEventListener&&i.addEventListener("load",f),i.onloadcssdefined=l,l(f),i};"undefined"!=typeof exports?exports.loadCSS=b:a.loadCSS=b})("undefined"!=typeof global?global:this);'
   content += ';(function(a){if(a.loadCSS){var b=loadCSS.relpreload={};if(b.support=function(){try{return a.document.createElement("link").relList.supports("preload")}catch(b){return!1}},b.poly=function(){for(var b=a.document.getElementsByTagName("link"),c=0;c<b.length;c++){var d=b[c];"preload"===d.rel&&"style"===d.getAttribute("as")&&(a.loadCSS(d.href,d,d.getAttribute("media")),d.rel=null)}},!b.support()){b.poly();var c=a.setInterval(b.poly,300);a.addEventListener&&a.addEventListener("load",function(){b.poly(),a.clearInterval(c)}),a.attachEvent&&a.attachEvent("onload",function(){a.clearInterval(c)})}}})(this);'
-  var header = `<script>${content}</script>`
-  return addToHead(header)
+  return `<script>${content}</script>`
 }
 
 function scriptTransform (opts) {
@@ -116,7 +119,7 @@ function scriptTransform (opts) {
   var base64 = 'sha512-' + opts.hash.base64Slice()
   var link = `/${hex}/bundle.js`
   var header = `<script src="${link}" defer integrity="${base64}"></script>`
-  return addToHead(header)
+  return header
 }
 
 // NOTE: in theory we should be able to add integrity checks to stylesheets too,
@@ -127,7 +130,7 @@ function styleTransform (opts) {
   var hex = opts.hash.toString('hex').slice(0, 16)
   var link = `/${hex}/bundle.css`
   var header = `<link rel="preload" as="style" href="${link}" onload="this.rel='stylesheet'">`
-  return addToHead(header)
+  return header
 }
 
 function loadFontsTransform (opts) {
@@ -135,14 +138,14 @@ function loadFontsTransform (opts) {
     if (!path.isAbsolute(font)) font = '/' + font
     return header + `<link rel="preload" as="font" crossorigin href="${font}">`
   }, '')
-  return addToHead(header)
+  return header
 }
 
 function manifestTransform () {
   var header = `
   <link rel="manifest" href="/manifest.json">
   `.replace(/\n +/g, '')
-  return addToHead(header)
+  return header
 }
 
 function viewportTransform () {
@@ -150,28 +153,28 @@ function viewportTransform () {
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
   `.replace(/\n +/g, '')
-  return addToHead(header)
+  return header
 }
 
 function descriptionTransform (opts) {
   var header = `
     <meta name="description" content="${opts.description}">
   `.replace(/\n +/g, '')
-  return addToHead(header)
+  return header
 }
 
 function themeColorTransform (opts) {
   var header = `
     <meta name="theme-color" content=${opts.color}>
   `.replace(/\n +/g, '')
-  return addToHead(header)
+  return header
 }
 
 function titleTransform (opts) {
   var header = `
     <title>${opts.title}</title>
   `.replace(/\n +/g, '')
-  return addToHead(header)
+  return header
 }
 
 function criticalTransform (opts) {
@@ -182,7 +185,7 @@ function reloadTransform (opts) {
   var bundle = opts.bundle
   var base64 = sha512(bundle)
   var header = `<script integrity="${base64}">${bundle}</script>`
-  return addToHead(header)
+  return header
 }
 
 function addToHead (str) {

--- a/lib/graph-document.js
+++ b/lib/graph-document.js
@@ -116,7 +116,7 @@ function preloadTag () {
 
 function scriptTag (opts) {
   var hex = opts.hash.toString('hex').slice(0, 16)
-  var base64 = 'sha512-' + opts.hash.base64Slice()
+  var base64 = 'sha512-' + opts.hash.toString('base64')
   var link = `/${hex}/bundle.js`
   return `<script src="${link}" defer integrity="${base64}"></script>`
 }


### PR DESCRIPTION
This changes `graph-document` to only use a single `hyperstream` to add all our `<head>` stuff. This should help speed things up a lot when SSR results in a large amount of html, since we only need to parse the html once (or twice during `build`, for inlining critical css) instead of ~10 times.