### PR TITLE
Exclude electron module from browserify transform in pre 9.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,6 +88,10 @@ function Bankai (entry, opts) {
       ? watchify(browserify(jsOpts))
       : browserify(jsOpts)
 
+    if (opts.electron) {
+      b.exclude('electron')
+    }
+
     if (!self.cssDisabled) {
       b.plugin(cssExtract, { out: createCssStream })
       b.ignore('sheetify/insert')


### PR DESCRIPTION
If left in, electron does not properly load the `electron` module but instead tries to load the app binary directly via the `path.txt`.

I believe the correct course of action should be to exclude the `electron` module from the browserify transform. This allows electron to load the module via the built in node `require()` in electron. It seems electron does some magic for it's own module by loading from its asar.

**Note:** I'm not sure which branch I should use for pre `9.0.0` patches like this. Let me know if anything needs to change.