### PR TITLE
Replace purifycss by purgecss

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ can be useful to know which optimizations we apply. This is a list:
 ### CSS
 - __sheetify:__ extract all inline CSS from JavaScript, and include it in
   `bundle.js`.
-- __purifyCSS:__ removes unused CSS from the project.
+- __purgeCSS:__ removes unused CSS from the project.
 - __cleanCSS:__ minify the bundle.
 
 ### HTML

--- a/lib/graph-style.js
+++ b/lib/graph-style.js
@@ -1,4 +1,4 @@
-var purify = require('purify-css')
+var Purgecss = require('purgecss')
 var Clean = require('clean-css')
 var assert = require('assert')
 
@@ -17,9 +17,15 @@ function node (state, createEdge) {
   var bundle
 
   try {
-    bundle = purify(script, style, { minify: true })
+    bundle = new Purgecss({
+      content: [{
+        raw: script
+      }],
+      css: [style],
+      stdin: true
+    }).purge()[0].css
   } catch (e) {
-    this.emit('error', 'styles', 'purify-css', e)
+    this.emit('error', 'styles', 'purgecss', e)
   }
 
   try {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "prettier-bytes": "^1.0.4",
     "pump": "^1.0.2",
     "pumpify": "^1.3.5",
-    "purify-css": "^1.2.5",
+    "purgecss": "^0.18.1",
     "recursive-readdir": "^2.2.1",
     "recursive-watch": "^1.1.2",
     "selfsigned": "^1.10.1",

--- a/test/style.js
+++ b/test/style.js
@@ -47,6 +47,7 @@ tape('remove unused styles', function (assert) {
     css\`
       .foo { color: blue }
       .bar { color: purple }
+      .foo2 { color: green }
     \`
     html\`<foo class="foo">hello</foo>\`
   `


### PR DESCRIPTION
## Proposed changes

[PurgeCss](https://github.com/FullHuman/purgecss) is a tool similar to purifycss. It is inspired by purifycss but fixes a lot of purifycss issues. One of those issues is the fact that purifycss does not take number into consideration.
e.g: `.classname1` and `.classname2` are the same for purifycss.
    