### PR TITLE
Support spread operators by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "babel-preset-env": "^1.6.1",
     "babelify": "^8.0.0",
     "brfs": "^1.4.3",
-    "browserify": "^14.4.0",
+    "browserify": "^15.0.0",
     "buffer-graph": "^4.0.0",
     "clean-css": "^4.1.8",
     "concat-stream": "^1.6.0",


### PR DESCRIPTION
This updates browserify major, which was supposed to drop node < 4.0 support.  It might not ultimately see https://github.com/browserify/browserify/pull/1794#pullrequestreview-87403598 but I want to get the spread operator support into bankai nonetheless. 