### PR TITLE
Detect if a project is an electron project

### DIFF
--- a/lib/cmd-start.js
+++ b/lib/cmd-start.js
@@ -1,28 +1,35 @@
 var getPort = require('get-port')
 
-var bankai = require('../http')
+var isElectronProject = require('./is-electron-project')
 var http = require('./http-server')
+var bankai = require('../http')
 
 module.exports = start
 
 function start (entry, opts) {
-  var handler = bankai(entry, opts)
-  var state = handler.state // TODO: move all UI code into this file
-  var server = http.createServer(function (req, res) {
-    if (req.type === 'OPTIONS') return cors(req, res)
-    handler(req, res, function () {
-      res.statusCode = 404
-      return res.end('No route found for ' + req.url)
-    })
-  })
+  isElectronProject(process.cwd(), function (err, bool) {
+    if (err) throw err
+    opts.electron = bool
 
-  getPort({port: 8080}).then(function (port) {
-    server.listen(port, function () {
-      state.port = port
+    var handler = bankai(entry, opts)
+    var state = handler.state // TODO: move all UI code into this file
+    var server = http.createServer(function (req, res) {
+      if (req.type === 'OPTIONS') return cors(req, res)
+      handler(req, res, function () {
+        res.statusCode = 404
+        return res.end('No route found for ' + req.url)
+      })
     })
-  })
-  .catch(function (err) {
-    state.error = err
+
+    getPort({port: 8080})
+      .then(function (port) {
+        server.listen(port, function () {
+          state.port = port
+        })
+      })
+      .catch(function (err) {
+        state.error = err
+      })
   })
 }
 

--- a/lib/is-electron-project.js
+++ b/lib/is-electron-project.js
@@ -8,17 +8,17 @@ module.exports = isElectronProject
 function isElectronProject (dirname, cb) {
   findup(dirname, 'package.json', function (err, dir) {
     if (err) return cb(null, false)
-    fs.readFile(path.join(dir, 'package.json', function (err, json) {
+    fs.readFile(path.join(dir, 'package.json'), function (err, json) {
       if (err) return cb(explain(err, 'bankai/lib/is-electron-project: error reading package.json'))
 
       try {
         var pkg = JSON.parse(json)
-        var hasElectronDep = (pkg.dependencies && pkg.dependencies.electron) ||
-          (pkg.devDependencies && pkg.devDependencies.electron)
+        var hasElectronDep = Boolean((pkg.dependencies && pkg.dependencies.electron) ||
+          (pkg.devDependencies && pkg.devDependencies.electron))
         cb(null, hasElectronDep)
       } catch (err) {
         if (err) return cb(explain(err, 'bankai/lib/is-electron-project: error parsing package.json'))
       }
-    }))
+    })
   })
 }

--- a/lib/is-electron-project.js
+++ b/lib/is-electron-project.js
@@ -1,0 +1,24 @@
+var explain = require('explain-error')
+var findup = require('findup')
+var path = require('path')
+var fs = require('fs')
+
+module.exports = isElectronProject
+
+function isElectronProject (dirname, cb) {
+  findup(dirname, 'package.json', function (err, dir) {
+    if (err) return cb(null, false)
+    fs.readFile(path.join(dir, 'package.json', function (err, json) {
+      if (err) return cb(explain(err, 'bankai/lib/is-electron-project: error reading package.json'))
+
+      try {
+        var pkg = JSON.parse(json)
+        var hasElectronDep = (pkg.dependencies && pkg.dependencies.electron) ||
+          (pkg.devDependencies && pkg.devDependencies.electron)
+        cb(null, hasElectronDep)
+      } catch (err) {
+        if (err) return cb(explain(err, 'bankai/lib/is-electron-project: error parsing package.json'))
+      }
+    }))
+  })
+}


### PR DESCRIPTION
This sets us up to add Electron support for Bankai. I was thinking that if we know a project has Electron as a dependency, we could launch it using their local Electron version. And build it using their local Electron-Builder.

Before any of that can be done, we need to detect if we're dealing with an Electron project in the first place. This does exactly that.

We chose to do add this logic to `cmd-start.js` first, because it doesn't feel like it belongs in either `index.js` or `http.js`. And not in `bin.js` either, because `lib/cmd-inspect` has no use for this either.

Hope this makes sense! Keen to receive feedback on this!

---
Paired with @blahah on this :sparkles: