### PR TITLE
Add X-Accel-Buffering: no to /reload's header

### DIFF
--- a/http.js
+++ b/http.js
@@ -185,6 +185,7 @@ function start (entry, opts) {
 
     res.writeHead(200, {
       'Content-Type': 'text/event-stream',
+      'X-Accel-Buffering': 'no',
       'Cache-Control': 'no-cache'
     })
     res.write('retry: 10000\n')


### PR DESCRIPTION
Hey! This is pretty obscure and edge-casey, and I'm not familiar with bankai internal; Please just close if this is not good for bankai. 

If you proxy nginx to bankai, the reloader SSE thing stops working.
Nginx is bufferering things so /reload sits at (pending)

If someone wanted to verify, the nginx conf would be something like:
```
server {
                listen                  443 ssl ;
                ssl_certificate         cert.pem;
                ssl_certificate_key     key.pem;
                server_name             tarvis.online;

                location / {
                        root   html;
                        proxy_set_header Host $host;
                        proxy_set_header X-Real-IP $remote_addr;
                        proxy_pass http://localhost:8080/; #<-bankai
                        #proxy_buffering off;
                }

        }
```
https://serverfault.com/questions/801628/for-server-sent-events-sse-what-nginx-proxy-configuration-is-appropriate
 > However, instead of turning proxy_buffering off for everything,
it's actually best (if you're able to) to add the X-Accel-Buffering: no
as a response header in your application server code to only turn buffering
off for the SSE based response and not for all responses coming from your app server.