### PR TITLE
Restore asset serving behavior

### DIFF
--- a/http.js
+++ b/http.js
@@ -117,7 +117,7 @@ function start (entry, opts) {
     })
   })
 
-  router.route(/\/([a-zA-Z0-9-_.]+)\.js\?{0,1}[\w&=]*$/, function (req, res, params) {
+  router.route(/\/([a-zA-Z0-9-_.]+)\.js(\?.*)?$/, function (req, res, params) {
     var name = params[1]
     compiler.scripts(name, function (err, node) {
       if (err) {
@@ -129,7 +129,7 @@ function start (entry, opts) {
     })
   })
 
-  router.route(/\/([a-zA-Z0-9-_.]+)\.css\?{0,1}[\w&=]*$/, function (req, res, params) {
+  router.route(/\/([a-zA-Z0-9-_.]+)\.css(\?.*)?$/, function (req, res, params) {
     var name = params[1]
     compiler.styles(name, function (err, node) {
       if (err) {
@@ -164,7 +164,7 @@ function start (entry, opts) {
     })
   })
 
-  router.route(/^\/assets\/([a-zA-Z0-9-_.]*)\?{0,1}[\w&=]*$/, function (req, res, params) {
+  router.route(/^\/assets\/([^?]*)(\?.*)?$/, function (req, res, params) {
     var prefix = 'assets' // TODO: also accept 'content'
     var name = prefix + '/' + params[1]
     compiler.assets(name, function (err, filename) {

--- a/http.js
+++ b/http.js
@@ -117,6 +117,18 @@ function start (entry, opts) {
     })
   })
 
+  router.route(/^\/assets\/([^?]*)(\?.*)?$/, function (req, res, params) {
+    var prefix = 'assets' // TODO: also accept 'content'
+    var name = prefix + '/' + params[1]
+    compiler.assets(name, function (err, filename) {
+      if (err) {
+        res.statusCode = 404
+        return res.end(err.message)
+      }
+      pump(send(req, filename), res)
+    })
+  })
+
   router.route(/\/([a-zA-Z0-9-_.]+)\.js(\?.*)?$/, function (req, res, params) {
     var name = params[1]
     compiler.scripts(name, function (err, node) {
@@ -161,18 +173,6 @@ function start (entry, opts) {
       }
       res.setHeader('content-type', 'application/json')
       gzip(node.buffer, req, res)
-    })
-  })
-
-  router.route(/^\/assets\/([^?]*)(\?.*)?$/, function (req, res, params) {
-    var prefix = 'assets' // TODO: also accept 'content'
-    var name = prefix + '/' + params[1]
-    compiler.assets(name, function (err, filename) {
-      if (err) {
-        res.statusCode = 404
-        return res.end(err.message)
-      }
-      pump(send(req, filename), res)
     })
   })
 

--- a/test/http.js
+++ b/test/http.js
@@ -53,10 +53,10 @@ function setup () {
   fs.writeFileSync(tmpJpgSubFilename, file)
 }
 
-tape.only('foo', function (assert) {
+tape('foo', function (assert) {
   setup()
   var handler = bankai(tmpScriptname, { watch: false, quiet: true })
-  var server = http.createServer(function(req, res) {
+  var server = http.createServer(function (req, res) {
     handler(req, res, function () {
       res.statusCode = 404
       res.end('not found')
@@ -90,7 +90,7 @@ tape.only('foo', function (assert) {
 
   var count = 0
   urls.forEach(function (url) {
-    http.get('http://localhost:3030' + url, function(res) {
+    http.get('http://localhost:3030' + url, function (res) {
       assert.equal(res.statusCode, 200, url)
       if (++count === urls.length) {
         server.close()
@@ -98,5 +98,4 @@ tape.only('foo', function (assert) {
       }
     })
   })
-
 })

--- a/test/http.js
+++ b/test/http.js
@@ -53,7 +53,7 @@ function setup () {
   fs.writeFileSync(tmpJpgSubFilename, file)
 }
 
-tape('foo', function (assert) {
+tape('should route urls appropriately', function (assert) {
   setup()
   var handler = bankai(tmpScriptname, { watch: false, quiet: true })
   var server = http.createServer(function (req, res) {

--- a/test/http.js
+++ b/test/http.js
@@ -1,0 +1,102 @@
+var dedent = require('dedent')
+var rimraf = require('rimraf')
+var path = require('path')
+var tape = require('tape')
+var fs = require('fs')
+var os = require('os')
+var http = require('http')
+
+var bankai = require('../http')
+
+var tmpDirname, tmpScriptname
+
+function cleanup () {
+  rimraf.sync(tmpDirname)
+}
+
+function setup () {
+  var script = dedent`
+    var css = require('sheetify')
+    var html = require('bel')
+    css\`
+      .foo { color: blue }
+    \`
+    html\`<foo class="foo">hello</foo>\`
+  `
+
+  var file = dedent`
+    hello planet
+  `
+
+  var dirname = 'manifest-pipeline-' + (Math.random() * 1e4).toFixed()
+  tmpDirname = path.join(os.tmpdir(), dirname)
+  var assetDirname = path.join(tmpDirname, 'assets')
+  var assetSubdirname = path.join(assetDirname, 'images')
+
+  tmpScriptname = path.join(tmpDirname, 'index.js')
+  var tmpFilename = path.join(assetDirname, 'file.txt')
+  var tmpAssetJsFilename = path.join(assetDirname, 'file.js')
+  var tmpAssetCssFilename = path.join(assetDirname, 'file.css')
+  var tmpJsonFilename = path.join(assetDirname, 'file.json')
+  var tmpJpgFilename = path.join(assetDirname, 'file.jpg')
+  var tmpJpgSubFilename = path.join(assetSubdirname, 'file.jpg')
+
+  fs.mkdirSync(tmpDirname)
+  fs.mkdirSync(assetDirname)
+  fs.mkdirSync(assetSubdirname)
+  fs.writeFileSync(tmpScriptname, script)
+  fs.writeFileSync(tmpFilename, file)
+  fs.writeFileSync(tmpAssetJsFilename, file)
+  fs.writeFileSync(tmpAssetCssFilename, file)
+  fs.writeFileSync(tmpJsonFilename, file)
+  fs.writeFileSync(tmpJpgFilename, file)
+  fs.writeFileSync(tmpJpgSubFilename, file)
+}
+
+tape.only('foo', function (assert) {
+  setup()
+  var handler = bankai(tmpScriptname, { watch: false, quiet: true })
+  var server = http.createServer(function(req, res) {
+    handler(req, res, function () {
+      res.statusCode = 404
+      res.end('not found')
+    })
+  })
+
+  server.listen(3030, function () {
+    console.log('listening on port 3030')
+  })
+
+  assert.on('end', cleanup)
+
+  var urls = [
+    '/bundle.js',
+    '/bundle.js?cache=busted',
+    '/bundle.css',
+    '/bundle.css?cache=busted',
+    '/assets/file.txt',
+    '/assets/file.txt?cache=busted',
+    '/assets/file.json',
+    '/assets/file.css',
+    '/assets/file.css?cache=busted',
+    '/assets/file.js',
+    '/assets/file.js?cache=busted',
+    '/assets/file.json?cache=busted',
+    '/assets/file.jpg',
+    '/assets/file.jpg?cache=busted',
+    '/assets/images/file.jpg',
+    '/assets/images/file.jpg?cache=busted'
+  ]
+
+  var count = 0
+  urls.forEach(function (url) {
+    http.get('http://localhost:3030' + url, function(res) {
+      assert.equal(res.statusCode, 200, url)
+      if (++count === urls.length) {
+        server.close()
+        assert.end()
+      }
+    })
+  })
+
+})

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 require('./assets')
 require('./document')
+require('./http')
 require('./manifest')
 require('./script')
 require('./style')


### PR DESCRIPTION
Attempts to address #382 

I added some tests around routing and updated the regex's for scripts, styles and assets.
Additionally I moved the asset route above the style and script routes so .js and .css files can be served from the assets/ directory without being first matched by the script and style compiler routes.