### PR TITLE
Revert "Replace purifycss by purgecss (#371)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ can be useful to know which optimizations we apply. This is a list:
 ### CSS
 - __sheetify:__ extract all inline CSS from JavaScript, and include it in
   `bundle.js`.
-- __purgeCSS:__ removes unused CSS from the project.
+- __purifyCSS:__ removes unused CSS from the project.
 - __cleanCSS:__ minify the bundle.
 
 ### HTML

--- a/lib/graph-style.js
+++ b/lib/graph-style.js
@@ -1,4 +1,4 @@
-var Purgecss = require('purgecss')
+var purify = require('purify-css')
 var Clean = require('clean-css')
 var assert = require('assert')
 
@@ -17,15 +17,9 @@ function node (state, createEdge) {
   var bundle
 
   try {
-    bundle = new Purgecss({
-      content: [{
-        raw: script
-      }],
-      css: [style],
-      stdin: true
-    }).purge()[0].css
+    bundle = purify(script, style, { minify: true })
   } catch (e) {
-    this.emit('error', 'styles', 'purgecss', e)
+    this.emit('error', 'styles', 'purify-css', e)
   }
 
   try {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "prettier-bytes": "^1.0.4",
     "pump": "^1.0.2",
     "pumpify": "^1.3.5",
-    "purgecss": "^0.18.1",
+    "purify-css": "^1.2.5",
     "recursive-readdir": "^2.2.1",
     "recursive-watch": "^1.1.2",
     "selfsigned": "^1.10.1",

--- a/test/style.js
+++ b/test/style.js
@@ -47,7 +47,6 @@ tape('remove unused styles', function (assert) {
     css\`
       .foo { color: blue }
       .bar { color: purple }
-      .foo2 { color: green }
     \`
     html\`<foo class="foo">hello</foo>\`
   `


### PR DESCRIPTION
This reverts commit 69f0ac80ebee76f774250cef6cc9a12463c7a4e3.

purgecss was removing the keyword classes from `hljs`, breaking the
highlighting on the choo website. revert to purify-css for now, which is
a bit more conservative.