### PR TITLE
Subresource integrity for split bundles

### DIFF
--- a/lib/graph-script.js
+++ b/lib/graph-script.js
@@ -84,7 +84,8 @@ function node (state, createEdge) {
       filename: function (record) {
         return 'bundle-' + record.index + '.js'
       },
-      output: bundleDynamicBundle
+      output: bundleDynamicBundle,
+      sri: 'sha512'
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "send": "^0.16.0",
     "server-router": "^6.0.0",
     "sheetify": "^7.0.0",
-    "split-require": "^2.0.0",
+    "split-require": "^2.1.0",
     "split2": "^2.1.1",
     "strip-ansi": "^4.0.0",
     "tfilter": "^1.0.1",


### PR DESCRIPTION
Uses the `sri: 'HASH_TYPE'` option for split-require to implement
subresource integrity for dynamically loaded bundles.