### PR TITLE
Update browserify to v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "send": "^0.16.1",
     "server-router": "^6.0.0",
     "sheetify": "^7.1.0",
-    "split-require": "^2.1.2",
+    "split-require": "^3.0.0",
     "split2": "^2.2.0",
     "strip-ansi": "^4.0.0",
     "tfilter": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babelify": "^8.0.0",
     "brfs": "^1.4.4",
     "brotli": "^1.3.2",
-    "browserify": "^15.2.0",
+    "browserify": "^16.0.0",
     "buffer-graph": "^4.0.0",
     "clean-css": "^4.1.9",
     "concat-stream": "^1.6.0",


### PR DESCRIPTION
This updates the `events` module, and `module-deps` too. `events`
technically contains a breaking change…but it's one of those that probably
won't actually affect anyone. the major bump was in part because the new
`events` version is twice the gzipped size of the old one.

module-deps@6 allows using persistent caching + watchify so we can start
using [browserify-persist-fs](https://npmjs.com/package/browserify-persist-fs)
for speedier builds.