### PR TITLE
Add output dir option to `bankai build`, closes #333

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -81,7 +81,8 @@ var argv = minimist(process.argv.slice(2), {
   } else if (argv.version) {
     console.log(require('./package.json').version)
   } else if (cmd === 'build') {
-    require('./lib/cmd-build')(path.join(entry), argv)
+    var outdir = argv._[2]
+    require('./lib/cmd-build')(path.join(entry), outdir, argv)
   } else if (cmd === 'inspect') {
     require('./lib/cmd-inspect')(path.join(entry), argv)
   } else if (cmd === 'start') {

--- a/lib/cmd-build.js
+++ b/lib/cmd-build.js
@@ -14,23 +14,24 @@ var utils = require('./utils')
 
 module.exports = build
 
-function build (entry, opts) {
-  var basedir = utils.dirname(entry)
-  var outdir = path.join(basedir, 'dist')
+function build (entry, outdir, opts) {
+  var bankaiOpts = {
+    logStream: pumpify(pinoColada(), process.stdout),
+    assert: false,
+    watch: false
+  }
+  var compiler = bankai(entry, bankaiOpts)
+  var log = compiler.log
+
+  if (!outdir) {
+    outdir = path.join(compiler.dirname, 'dist')
+  }
 
   mkdirp(outdir, function (err) {
     if (err) return console.error(err)
 
-    var bankaiOpts = {
-      logStream: pumpify(pinoColada(), process.stdout),
-      assert: false,
-      watch: false
-    }
-    var compiler = bankai(entry, bankaiOpts)
-    var log = compiler.log
-
     log.info('Compiling & compressing files\n')
-    created(basedir, outdir + '/')
+    created(compiler.dirname, outdir + '/')
 
     compiler.on('error', function (topic, sub, err) {
       if (err.pretty) log.error(err.pretty)
@@ -69,7 +70,7 @@ function build (entry, opts) {
       // TODO: It'd be sick if we could optimize our paths to assets,
       // add etags to our tags and put them in the right dir.
       function copyFile (src, done) {
-        var dest = path.join(outdir, path.relative(basedir, src))
+        var dest = path.join(outdir, path.relative(compiler.dirname, src))
         var dirname = utils.dirname(dest)
 
         if (dirname === dest) {
@@ -94,7 +95,7 @@ function build (entry, opts) {
           })
           function fin (err) {
             if (err) return done(err)
-            created(basedir, src)
+            created(compiler.dirname, dest)
             done()
           }
         }
@@ -194,7 +195,7 @@ function build (entry, opts) {
         function raw (done) {
           fs.writeFile(filename, buffer, function (err) {
             if (err) return done(err)
-            created(basedir, filename)
+            created(compiler.dirname, filename)
             done()
           })
         },
@@ -204,7 +205,7 @@ function build (entry, opts) {
             var outfile = filename + '.gz'
             fs.writeFile(outfile, compressed, function (err) {
               if (err) return done(err)
-              created(basedir, outfile)
+              created(compiler.dirname, outfile)
               done()
             })
           })
@@ -215,7 +216,7 @@ function build (entry, opts) {
             var outfile = filename + '.deflate'
             fs.writeFile(outfile, compressed, function (err) {
               if (err) return done(err)
-              created(basedir, outfile)
+              created(compiler.dirname, outfile)
               done()
             })
           })
@@ -225,7 +226,7 @@ function build (entry, opts) {
             var outfile = filename + '.br'
             fs.writeFile(outfile, compressed, function (err) {
               if (err) return done(err)
-              created(basedir, outfile)
+              created(compiler.dirname, outfile)
               done()
             })
           }).catch(done)

--- a/lib/cmd-start.js
+++ b/lib/cmd-start.js
@@ -7,11 +7,12 @@ var bankai = require('../http')
 module.exports = start
 
 function start (entry, opts) {
-  isElectronProject(process.cwd(), function (err, bool) {
+  var handler = bankai(entry, opts)
+
+  isElectronProject(handler.dirname, function (err, bool) {
     if (err) throw err
     opts.electron = bool
 
-    var handler = bankai(entry, opts)
     var state = handler.state // TODO: move all UI code into this file
     var server = http.createServer(function (req, res) {
       if (req.type === 'OPTIONS') return cors(req, res)


### PR DESCRIPTION
Provide a folder name in the third arg:

```
bankai build ./entry.js ./dist
```

This patch also changes it to use `compiler.dirname` to calculate the default output path; this should help fix #408 later.