### PR TITLE
Move UI code out of http.js

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -6,7 +6,6 @@ require('v8-compile-cache')
 
 var ansi = require('ansi-escape-sequences')
 var minimist = require('minimist')
-var dedent = require('dedent')
 var path = require('path')
 
 var USAGE = `

--- a/bin.js
+++ b/bin.js
@@ -133,7 +133,6 @@ var argv = minimist(process.argv.slice(2), {
   } else if (cmd === 'inspect') {
     require('./lib/cmd-inspect')(path.join(entry), argv)
   } else if (cmd === 'start') {
-    if (!argv.q) alternateBuffer()
     require('./lib/cmd-start')(path.join(entry), argv)
   } else {
     console.log(NOCOMMAND)
@@ -143,51 +142,4 @@ var argv = minimist(process.argv.slice(2), {
 
 function clr (text, color) {
   return process.stdout.isTTY ? ansi.format(text, color) : text
-}
-
-// Switch to an alternate terminal buffer,
-// switch back to the main terminal buffer on exit.
-function alternateBuffer () {
-  var q = Buffer.from('q')
-  var esc = Buffer.from([0x1B])
-
-  process.stdout.write('\x1b[?1049h') // Enter alternate buffer.
-  process.stdout.write('\x1b[H') // Reset screen to top.
-  process.stdout.write('\x1b[?25l') // Hide cursor
-
-  process.on('unhandledRejection', onexit)
-  process.on('uncaughtException', onexit)
-  process.on('SIGTERM', onexit)
-  process.on('SIGINT', onexit)
-  process.on('exit', onexit)
-  process.stdin.on('data', handleKey)
-
-  function handleKey (buf) {
-    if (buf.compare(q) === 0 || buf.compare(esc) === 0) {
-      onexit()
-    }
-  }
-
-  function onexit (statusCode) {
-    process.stdout.write('\x1b[?1049l') // Enter to main buffer.
-    process.stdout.write('\x1b[?25h') // Restore cursor
-
-    if (statusCode instanceof Error) {
-      console.error('A critical error occured, forcing Bankai to abort:\n')
-      console.error(clr(statusCode.stack, 'red') + '\n')
-      console.error(dedent`
-        If you think this might be a bug in Bankai, please consider helping
-        improve Bankai's stability by submitting an error to:
-
-        ${'  ' + clr('https://github.com/choojs/bankai/issues/new', 'underline')}
-
-        Please include the steps to reproduce this error, the stack trace
-        printed above, your version of Node, and your version of npm. Thanks!
-        ${clr('— Team Choo', 'italic')}
-      ` + '\n')
-      statusCode = 1
-    }
-
-    process.exit(statusCode)
-  }
 }

--- a/http.js
+++ b/http.js
@@ -7,7 +7,7 @@ var pump = require('pump')
 var send = require('send')
 
 var Router = require('./lib/regex-router')
-var ui = require('./lib/ui')
+var ui = require('./lib/ui-basic')
 var bankai = require('./')
 
 var files = [

--- a/http.js
+++ b/http.js
@@ -8,15 +8,6 @@ var send = require('send')
 var Router = require('./lib/regex-router')
 var bankai = require('./')
 
-var files = [
-  'assets',
-  'documents',
-  'scripts',
-  'manifest',
-  'styles',
-  'service-worker'
-]
-
 module.exports = start
 
 function start (entry, opts) {

--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ module.exports = Bankai
 
 function Bankai (entry, opts) {
   if (!(this instanceof Bankai)) return new Bankai(entry, opts)
+
+  Emitter.call(this)
+
   opts = opts || {}
   this.local = localization(opts.language || 'en-US')
   this.log = pino(opts.logStream || process.stdout)

--- a/lib/cmd-start.js
+++ b/lib/cmd-start.js
@@ -3,7 +3,8 @@ var getPort = require('get-port')
 var isElectronProject = require('./is-electron-project')
 var http = require('./http-server')
 var bankai = require('../http')
-var ui = require('./ui')
+var createTui = require('./ui')
+var createLogUi = require('./ui-basic')
 
 module.exports = start
 
@@ -23,7 +24,8 @@ function start (entry, opts) {
       })
     })
 
-    var render = ui(handler.compiler, state)
+    var createUi = opts.simple ? createLogUi : createTui
+    var render = createUi(handler.compiler, state)
     render()
 
     getPort({port: 8080})

--- a/lib/cmd-start.js
+++ b/lib/cmd-start.js
@@ -3,6 +3,7 @@ var getPort = require('get-port')
 var isElectronProject = require('./is-electron-project')
 var http = require('./http-server')
 var bankai = require('../http')
+var ui = require('./ui')
 
 module.exports = start
 
@@ -21,6 +22,9 @@ function start (entry, opts) {
         return res.end('No route found for ' + req.url)
       })
     })
+
+    var render = ui(handler.compiler, state)
+    render()
 
     getPort({port: 8080})
       .then(function (port) {

--- a/lib/cmd-start.js
+++ b/lib/cmd-start.js
@@ -10,12 +10,15 @@ module.exports = start
 
 function start (entry, opts) {
   var handler = bankai(entry, opts)
+  var state = handler.state
+
+  var createUi = opts.simple ? createLogUi : createTui
+  var render = createUi(handler.compiler, state)
 
   isElectronProject(handler.compiler.dirname, function (err, bool) {
     if (err) throw err
     opts.electron = bool
 
-    var state = handler.state // TODO: move all UI code into this file
     var server = http.createServer(function (req, res) {
       if (req.type === 'OPTIONS') return cors(req, res)
       handler(req, res, function () {
@@ -24,8 +27,6 @@ function start (entry, opts) {
       })
     })
 
-    var createUi = opts.simple ? createLogUi : createTui
-    var render = createUi(handler.compiler, state)
     render()
 
     getPort({port: 8080})

--- a/lib/fatal-error.js
+++ b/lib/fatal-error.js
@@ -1,0 +1,23 @@
+var ansi = require('ansi-escape-sequences')
+var dedent = require('dedent')
+
+function clr (text, color) {
+  return process.stdout.isTTY ? ansi.format(text, color) : text
+}
+
+module.exports = function fatalError (err) {
+  return dedent`
+    A critical error occured, forcing Bankai to abort:
+    ${clr(err.stack, 'red')}
+
+    If you think this might be a bug in Bankai, please consider helping
+    improve Bankai's stability by submitting an error to:
+
+      ${clr('https://github.com/choojs/bankai/issues/new', 'underline')}
+
+    Please include the steps to reproduce this error, the stack trace
+    printed above, your version of Node, and your version of npm. Thanks!
+    ${clr('— Team Choo', 'italic')}
+
+  `
+}

--- a/lib/graph-assets.js
+++ b/lib/graph-assets.js
@@ -17,7 +17,6 @@ var dirs = [
 // 3. Estimate total size of all files combined, and emit `size`.
 //
 // TODO: optimize assets (on the fly); e.g. convert images to webp, etc.
-// TODO: also emit `progress`.
 
 module.exports = node
 
@@ -43,7 +42,7 @@ function node (state, createEdge) {
   })
 
   tracker.on('progress', function (progress) {
-    // self.emit('progress', 'assets', progress)
+    self.emit('progress', 'assets', progress)
   })
 
   this.on('close', function () {

--- a/lib/ui-basic.js
+++ b/lib/ui-basic.js
@@ -1,6 +1,5 @@
 var nanoraf = require('nanoraf')
 var pretty = require('prettier-bytes')
-module.exports = render
 
 module.exports = createLogUI
 

--- a/lib/ui-basic.js
+++ b/lib/ui-basic.js
@@ -2,7 +2,57 @@ var nanoraf = require('nanoraf')
 var pretty = require('prettier-bytes')
 module.exports = render
 
-function render (state) {
+module.exports = createLogUI
+
+var files = [
+  'assets',
+  'documents',
+  'scripts',
+  'styles',
+  'manifest',
+  'service-worker'
+]
+
+function createLogUI (compiler, state) {
+  Object.assign(state, {
+    count: compiler.metadata.count,
+    files: {},
+    size: 0
+  })
+
+  files.forEach(function (filename) {
+    state.files[filename] = {
+      size: 0,
+      status: 'pending',
+    }
+  })
+
+  var render = nanoraf(onrender, raf)
+
+  compiler.on('change', function (nodeName, edgeName, nodeState) {
+    var node = nodeState[nodeName][edgeName]
+    var data = {
+      size: 0,
+      status: 'done',
+    }
+    state.files[nodeName] = data
+
+    // Only calculate the gzip size if there's a buffer. Apparently zipping
+    // an empty file means it'll pop out with a 20B base size.
+    if (node.buffer.length) {
+      gzipSize(node.buffer)
+        .then(function (size) { data.size = size })
+        .catch(function () { data.size = node.buffer.length })
+        .then(render)
+    } else {
+      render()
+    }
+  })
+
+  compiler.on('progress', render)
+  compiler.on('sse-connect', render)
+  compiler.on('sse-disconnect', render)
+
   var diff = new Differ(state)
 
   var renderRaf = nanoraf(onrender, raf)
@@ -23,7 +73,7 @@ function view (state) {
     if (state.ssr.success) ssrState = 'Success'
     else ssrState = 'Skipped - ' + state.ssr.error.message
   }
-  var SSEStatus = state.sse > 0 ? 'connected' : state.port ? 'ready' : 'starting'
+  var sseStatus = state.sse > 0 ? 'connected' : state.port ? 'ready' : 'starting'
   var httpStatus = state.port ? 'https://localhost:' + state.port : 'starting'
 
   var allFilesDone = true
@@ -37,7 +87,7 @@ function view (state) {
 
   var output = [
     `bankai: HTTP Status: ${httpStatus}`,
-    `bankai: Live Reload: ${SSEStatus}`,
+    `bankai: Live Reload: ${sseStatus}`,
     `bankai: Server Side Rendering: ${ssrState}`,
     `bankai: assets ${files.assets ? files.assets.status : 'starting'}`,
     `bankai: documents ${files.documents ? files.documents.status : 'starting'}`,

--- a/lib/ui-basic.js
+++ b/lib/ui-basic.js
@@ -1,0 +1,67 @@
+var nanoraf = require('nanoraf')
+var pretty = require('prettier-bytes')
+module.exports = render
+
+function render (state) {
+  var diff = new Differ(state)
+
+  var renderRaf = nanoraf(onrender, raf)
+  return renderRaf
+
+  function onrender () {
+    diff.update(state)
+  }
+}
+
+function raf (cb) {
+  setTimeout(cb, 50)
+}
+
+function view (state) {
+  var ssrState = 'Pending'
+  if (state.ssr) {
+    if (state.ssr.success) ssrState = 'Success'
+    else ssrState = 'Skipped - ' + state.ssr.error.message
+  }
+  var SSEStatus = state.sse > 0 ? 'connected' : state.port ? 'ready' : 'starting'
+  var httpStatus = state.port ? 'https://localhost:' + state.port : 'starting'
+
+  var allFilesDone = true
+  var size = Object.keys(state.files).reduce(function (num, filename) {
+    var file = state.files[filename]
+    if (file.status !== 'done') allFilesDone = false
+    return num + file.size
+  }, 0)
+
+  var files = state.files
+
+  var output = [
+    `bankai: HTTP Status: ${httpStatus}`,
+    `bankai: Live Reload: ${SSEStatus}`,
+    `bankai: Server Side Rendering: ${ssrState}`,
+    `bankai: assets ${files.assets ? files.assets.status : 'starting'}`,
+    `bankai: documents ${files.documents ? files.documents.status : 'starting'}`,
+    `bankai: scripts ${files.scripts ? files.scripts.status : 'starting'}`,
+    `bankai: styles ${files.styles ? files.styles.status : 'starting'}`,
+    `bankai: manifest ${files.manifest ? files.manifest.status : 'starting'}`,
+    `bankai: service-worker ${files['service-worker'] ? files['service-worker'].status : 'starting'}`,
+    `bankai: Total File size: ${allFilesDone ? pretty(size).replace(' ', '') : 'pending'} `
+  ]
+  return output
+}
+
+function Differ (state) {
+  var logLines = view(state)
+  console.log(logLines.join('\n'))
+  this.oldState = logLines
+}
+
+Differ.prototype.update = function (state) {
+  var newState = view(state)
+
+  this.oldState.forEach((line, i) => {
+    if (line !== newState[i]) console.log(newState[i])
+  })
+
+  this.oldState = newState
+}

--- a/lib/ui-basic.js
+++ b/lib/ui-basic.js
@@ -23,7 +23,7 @@ function createLogUI (compiler, state) {
   files.forEach(function (filename) {
     state.files[filename] = {
       size: 0,
-      status: 'pending',
+      status: 'pending'
     }
   })
 
@@ -33,7 +33,7 @@ function createLogUI (compiler, state) {
     var node = nodeState[nodeName][edgeName]
     var data = {
       size: 0,
-      status: 'done',
+      status: 'done'
     }
     state.files[nodeName] = data
 

--- a/lib/ui-basic.js
+++ b/lib/ui-basic.js
@@ -1,5 +1,6 @@
 var nanoraf = require('nanoraf')
 var pretty = require('prettier-bytes')
+var gzipSize = require('gzip-size')
 
 module.exports = createLogUI
 

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -1,7 +1,8 @@
 var ansi = require('ansi-escape-sequences')
-var differ = require('ansi-diff')
 var pretty = require('prettier-bytes')
+var gzipSize = require('gzip-size')
 var keypress = require('keypress')
+var differ = require('ansi-diff')
 var strip = require('strip-ansi')
 var nanoraf = require('nanoraf')
 
@@ -25,11 +26,63 @@ module.exports = createUi
 function createUi (compiler, state) {
   var diff = differ()
 
+  Object.assign(state, {
+    count: compiler.metadata.count,
+    files: {},
+    size: 0
+  })
+
   var render = nanoraf(onrender, raf)
 
-  compiler.on('error', render)
-  compiler.on('progress', render)
-  compiler.on('change', render)
+  files.forEach(function (filename) {
+    state.files[filename] = {
+      name: filename,
+      progress: 0,
+      timestamp: '        ',
+      size: 0,
+      status: 'pending',
+      done: false
+    }
+  })
+
+  compiler.on('error', function (topic, sub, err) {
+    if (err.pretty) state.error = err.pretty
+    else state.error = `${topic}:${sub} ${err.message}\n${err.stack}`
+    render()
+  })
+
+  compiler.on('progress', function () {
+    state.error = null
+    render()
+  })
+
+  compiler.on('change', function (nodeName, edgeName, nodeState) {
+    var node = nodeState[nodeName][edgeName]
+    var name = nodeName + ':' + edgeName
+    var data = {
+      name: nodeName,
+      progress: 100,
+      timestamp: time(),
+      size: 0,
+      status: 'done',
+      done: true
+    }
+    state.files[nodeName] = data
+
+    // Only calculate the gzip size if there's a buffer. Apparently zipping
+    // an empty file means it'll pop out with a 20B base size.
+    if (node.buffer.length) {
+      gzipSize(node.buffer, function (err, size) {
+        if (err) data.size = node.buffer.length
+        else data.size = size
+        render()
+      })
+    }
+    render()
+  })
+
+  compiler.on('sse-connect', render)
+  compiler.on('sse-disconnect', render)
 
   process.stdout.on('resize', onresize)
 
@@ -211,4 +264,17 @@ function spaceBetween (left, right) {
     space += ' '
   }
   return left + space + right
+}
+
+function time () {
+  var date = new Date()
+  var hours = numPad(date.getHours())
+  var minutes = numPad(date.getMinutes())
+  var seconds = numPad(date.getSeconds())
+  return `${hours}:${minutes}:${seconds}`
+}
+
+function numPad (num) {
+  if (num < 10) num = '0' + num
+  return num
 }

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -58,7 +58,6 @@ function createUi (compiler, state) {
 
   compiler.on('change', function (nodeName, edgeName, nodeState) {
     var node = nodeState[nodeName][edgeName]
-    var name = nodeName + ':' + edgeName
     var data = {
       name: nodeName,
       progress: 100,

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -71,11 +71,10 @@ function createUi (compiler, state) {
     // Only calculate the gzip size if there's a buffer. Apparently zipping
     // an empty file means it'll pop out with a 20B base size.
     if (node.buffer.length) {
-      gzipSize(node.buffer, function (err, size) {
-        if (err) data.size = node.buffer.length
-        else data.size = size
-        render()
-      })
+      gzipSize(node.buffer)
+        .then(function (size) { data.size = size })
+        .catch(function (size) { data.size = node.buffer.length })
+        .then(render)
     }
     render()
   })
@@ -171,7 +170,7 @@ function view (state) {
 
 // header
 function header (state) {
-  var SSEStatus = state.sse > 0
+  var sseStatus = state.sse > 0
     ? clr('connected', 'green')
     : state.port
       ? 'ready'
@@ -182,7 +181,7 @@ function header (state) {
     : clr('starting', 'yellow')
 
   var left = `HTTP: ${httpStatus}`
-  var right = `Live Reload: ${SSEStatus}`
+  var right = `Live Reload: ${sseStatus}`
   return spaceBetween(left, right)
 }
 

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -20,12 +20,16 @@ var files = [
   'service-worker'
 ]
 
-module.exports = render
+module.exports = createUi
 
-function render (state) {
+function createUi (compiler, state) {
   var diff = differ()
 
   var render = nanoraf(onrender, raf)
+
+  compiler.on('error', render)
+  compiler.on('progress', render)
+  compiler.on('change', render)
 
   process.stdout.on('resize', onresize)
 

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -25,6 +25,7 @@ module.exports = createUi
 
 function createUi (compiler, state) {
   var diff = differ()
+  alternateBuffer()
 
   Object.assign(state, {
     count: compiler.metadata.count,
@@ -275,4 +276,49 @@ function time () {
 function numPad (num) {
   if (num < 10) num = '0' + num
   return num
+}
+
+function alternateBuffer () {
+  var q = Buffer.from('q')
+  var esc = Buffer.from([0x1B])
+
+  process.stdout.write('\x1b[?1049h') // Enter alternate buffer.
+  process.stdout.write('\x1b[H')      // Reset screen to top.
+  process.stdout.write('\x1b[?25l')   // Hide cursor
+
+  process.on('unhandledRejection', onexit)
+  process.on('uncaughtException', onexit)
+  process.on('SIGTERM', onexit)
+  process.on('SIGINT', onexit)
+  process.on('exit', onexit)
+  process.stdin.on('data', handleKey)
+
+  function handleKey (buf) {
+    if (buf.compare(q) === 0 || buf.compare(esc) === 0) {
+      onexit()
+    }
+  }
+
+  function onexit (statusCode) {
+    process.stdout.write('\x1b[?1049l')  // Enter to main buffer.
+    process.stdout.write('\x1b[?25h')    // Restore cursor
+
+    if (statusCode instanceof Error) {
+      console.error('A critical error occured, forcing Bankai to abort:\n')
+      console.error(clr(statusCode.stack, 'red') + '\n')
+      console.error(dedent`
+        If you think this might be a bug in Bankai, please consider helping
+        improve Bankai's stability by submitting an error to:
+
+        ${'  ' + clr('https://github.com/choojs/bankai/issues/new', 'underline')}
+
+        Please include the steps to reproduce this error, the stack trace
+        printed above, your version of Node, and your version of npm. Thanks!
+        ${clr('— Team Choo', 'italic')}
+      ` + '\n')
+      statusCode = 1
+    }
+
+    process.exit(statusCode)
+  }
 }

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -54,8 +54,9 @@ function createUi (compiler, state) {
 
   compiler.on('ssr', render)
 
-  compiler.on('progress', function () {
+  compiler.on('progress', function (nodeName, progress) {
     state.error = null
+    state.files[nodeName].progress = progress
     render()
   })
 

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -52,6 +52,8 @@ function createUi (compiler, state) {
     render()
   })
 
+  compiler.on('ssr', render)
+
   compiler.on('progress', function () {
     state.error = null
     render()

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -5,6 +5,7 @@ var keypress = require('keypress')
 var differ = require('ansi-diff')
 var strip = require('strip-ansi')
 var nanoraf = require('nanoraf')
+var fatalError = require('./fatal-error')
 
 var StartDelimiter = '|'
 var EndDelimiter = '|'
@@ -286,8 +287,8 @@ function alternateBuffer () {
   var esc = Buffer.from([0x1B])
 
   process.stdout.write('\x1b[?1049h') // Enter alternate buffer.
-  process.stdout.write('\x1b[H')      // Reset screen to top.
-  process.stdout.write('\x1b[?25l')   // Hide cursor
+  process.stdout.write('\x1b[H') // Reset screen to top.
+  process.stdout.write('\x1b[?25l') // Hide cursor
 
   process.on('unhandledRejection', onexit)
   process.on('uncaughtException', onexit)
@@ -303,22 +304,11 @@ function alternateBuffer () {
   }
 
   function onexit (statusCode) {
-    process.stdout.write('\x1b[?1049l')  // Enter to main buffer.
-    process.stdout.write('\x1b[?25h')    // Restore cursor
+    process.stdout.write('\x1b[?1049l') // Enter to main buffer.
+    process.stdout.write('\x1b[?25h') // Restore cursor
 
     if (statusCode instanceof Error) {
-      console.error('A critical error occured, forcing Bankai to abort:\n')
-      console.error(clr(statusCode.stack, 'red') + '\n')
-      console.error(dedent`
-        If you think this might be a bug in Bankai, please consider helping
-        improve Bankai's stability by submitting an error to:
-
-        ${'  ' + clr('https://github.com/choojs/bankai/issues/new', 'underline')}
-
-        Please include the steps to reproduce this error, the stack trace
-        printed above, your version of Node, and your version of npm. Thanks!
-        ${clr('— Team Choo', 'italic')}
-      ` + '\n')
+      console.error(fatalError(statusCode))
       statusCode = 1
     }
 


### PR DESCRIPTION
Moves all the UI `state` stuff into lib/ui.js. the live reload connection counter `state.sse` is still managed by http.js, it emits `sse-connect` and `sse-disconnect` when the value updates so the UI can rerender. Maybe the counting should also happen in the UI code, with http.js only emitting those events?

Also added in @Flet's simple log output UI, just to make sure that the UI is indeed separate from the HTTP server now :)