### PR TITLE
Expose `compiler` on http handler

### DIFF
--- a/http.js
+++ b/http.js
@@ -262,6 +262,8 @@ function start (entry, opts) {
 
   // TODO: move all UI code out of this file
   handler.state = state
+  // Expose compiler so we can use it in `bankai start`
+  handler.compiler = compiler
   return handler
 
   // Return a handler to listen.

--- a/lib/cmd-start.js
+++ b/lib/cmd-start.js
@@ -9,7 +9,7 @@ module.exports = start
 function start (entry, opts) {
   var handler = bankai(entry, opts)
 
-  isElectronProject(handler.dirname, function (err, bool) {
+  isElectronProject(handler.compiler.dirname, function (err, bool) {
     if (err) throw err
     opts.electron = bool
 


### PR DESCRIPTION
So we can use the resolved `dirname` in `bankai start`.

Fixes #424.
Fixes https://github.com/choojs/create-choo-app/issues/52.
