### PR TITLE
Fix split-require integrity hashes

### DIFF
--- a/lib/graph-document.js
+++ b/lib/graph-document.js
@@ -135,8 +135,9 @@ function dynamicScriptsTag (opts) {
     name = name.replace(/\.js$/, '')
     var hash = opts.scripts[name].hash
     var hex = hash.toString('hex').slice(0, 16)
+    var base64 = 'sha512-' + hash.toString('base64')
     var link = `${opts.base || ''}/${hex}/${name}.js`
-    return `<link rel="prefetch" href="${link}">`
+    return `<link rel="prefetch" href="${link}" integrity="${base64}">`
   }).join('')
 }
 

--- a/lib/graph-script.js
+++ b/lib/graph-script.js
@@ -1,6 +1,6 @@
 var debug = require('debug')('bankai.node-script')
 var concat = require('concat-stream')
-var to = require('flush-write-stream')
+var exorcist = require('exorcist')
 var tfilter = require('tfilter')
 var assert = require('assert')
 
@@ -90,6 +90,11 @@ function node (state, createEdge) {
       output: bundleDynamicBundle,
       sri: 'sha512'
     })
+    // Run exorcist as part of the split-require pipeline, so that
+    // it can generate correct hashes for dynamic bundles.
+    b.on('split.pipeline', function (pipeline, entry, name) {
+      pipeline.get('wrap').push(exorciseDynamicBundle(name))
+    })
   }
 
   if (shouldMinify) {
@@ -124,31 +129,23 @@ function node (state, createEdge) {
     })
   }
 
+  function exorciseDynamicBundle (bundleName) {
+    var mapName = bundleName + '.map'
+    return exorcist(concat({ encoding: 'buffer' }, function (map) {
+      createEdge(mapName, map)
+    }), mapName)
+  }
+
   function bundleDynamicBundle (bundleName) {
     var edgeName = bundleName.replace(/\.js$/, '')
-    var buffers = []
-    return to(onwrite, onend)
-    function onwrite (chunk, enc, cb) {
-      buffers.push(chunk)
-      cb(null)
-    }
-    function onend (cb) {
-      var self = this
+    var stream = concat({ encoding: 'buffer' }, function (bundle) {
       dynamicBundles.push(bundleName)
+      createEdge(edgeName, bundle)
 
-      var mapName = bundleName + '.map'
-      var bundle = Buffer.concat(buffers)
-      exorcise(bundle, mapName, function (err, bundle, map) {
-        if (err) return self.emit('error', 'scripts', 'exorcise', err)
-        createEdge(mapName, Buffer.from(map))
-        createEdge(edgeName, bundle)
-
-        // Inform the main bundle about this file's full name.
-        self.emit('name', state.scripts[edgeName].hash.toString('hex').slice(0, 16) + '/' + bundleName)
-
-        cb()
-      })
-    }
+      // Inform the main bundle about this file's full name.
+      stream.emit('name', state.scripts[edgeName].hash.toString('hex').slice(0, 16) + '/' + bundleName)
+    })
+    return stream
   }
 
   function bundleStyles () {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "send": "^0.16.1",
     "server-router": "^6.0.0",
     "sheetify": "^7.1.0",
-    "split-require": "^3.0.0",
+    "split-require": "^3.0.1",
     "split2": "^2.2.0",
     "strip-ansi": "^4.0.0",
     "tfilter": "^1.0.1",


### PR DESCRIPTION
Previously we were telling split-require to generate a sha512 hash, but
then removing the source map from dynamic bundles afterwards,
invalidating the hash.

With this change we run exorcist as the very last part of the
split-require pipeline, by listening to the `split.pipeline` event. This
way split-require will generate hashes for the files _after_ source maps
have been externalised.

Also added integrity hashes to the prefetch links while debugging to
check whether they were the same; per
https://medium.com/reloading/preload-prefetch-and-priorities-in-chrome-776165961bbf#6dca
I'm not sure if this does anything or if prefetching at all might be
counterproductive.