### PR TITLE
Enable envify in watch mode (bankai start), fixes #431

### DIFF
--- a/lib/graph-script.js
+++ b/lib/graph-script.js
@@ -15,6 +15,7 @@ var sheetify = require('sheetify')
 var yoyoify = require('yo-yoify')
 var tinyify = require('tinyify')
 var glslify = require('glslify')
+var envify = require('envify/custom')
 var brfs = require('brfs')
 
 var ttyError = require('./tty-error')
@@ -103,13 +104,19 @@ function node (state, createEdge) {
     b.on('split.pipeline', function (pipeline) {
       tinyify.applyToPipeline(pipeline, b._options)
     })
+  } else {
+    var env = Object.assign({
+      NODE_ENV: 'development'
+    }, process.env)
+    b.transform(envify(env), { global: true })
   }
 
   bundleScripts()
   b.on('update', bundleScripts)
 
   var dynamicBundles
-  function bundleScripts () {
+  function bundleScripts (files) {
+    if (files) debug('triggering update because of changes in', files)
     self.emit('progress', 'scripts', 30)
 
     dynamicBundles = []

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "dedent": "^0.7.0",
     "disc": "^1.3.3",
     "documentify": "^3.1.0",
+    "envify": "^4.1.0",
     "exorcist": "^1.0.0",
     "explain-error": "^1.0.4",
     "fast-json-parse": "^1.0.3",


### PR DESCRIPTION
This was removed when we disabled minification in dev. Adding it back; the NODE_ENV variable defaults to `"development"` but you can override it still by doing `NODE_ENV=whatever bankai start`.