### PR TITLE
Lookup browserslist config

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ JavaScript in, and outputs JavaScript based for the platforms you've decided to
 target. In Bankai we target the last 2 versions of FireFox, Chrome and Edge,
 and every other browser that's used by more than 1% of people on earth. This
 includes IE11. And if you have different opinions on which browsers to use,
-Bankai respects `.babelrc` files.
+Bankai respects `.babelrc` and [`.browserslistrc`](https://github.com/ai/browserslist) files.
 
 Some newer JavaScript features require loading an extra library; `async/await`
 being the clearest example. To enable this features, the `babel-polyfill`

--- a/lib/graph-script.js
+++ b/lib/graph-script.js
@@ -6,6 +6,7 @@ var assert = require('assert')
 
 var babelPresetEnv = require('babel-preset-env')
 var splitRequire = require('split-require')
+var browserslist = require('browserslist')
 var cssExtract = require('css-extract')
 var browserify = require('browserify')
 var babelify = require('babelify')
@@ -19,19 +20,12 @@ var brfs = require('brfs')
 var ttyError = require('./tty-error')
 var exorcise = require('./exorcise')
 
-// Browsers to support in Babel.
-var browsers = [
+var defaultBrowsers = [
   'last 2 Chrome versions',
   'last 2 Firefox versions',
   'last 2 Safari versions',
   'last 2 Edge versions',
   '> 1%' // Cover all other browsers that are widely used.
-]
-
-var babelPresets = [
-  [babelPresetEnv, {
-    targets: { browsers: browsers }
-  }]
 ]
 
 module.exports = node
@@ -46,6 +40,16 @@ function node (state, createEdge) {
   var fullPaths = Boolean(state.metadata.fullPaths)
   var b = browserify(browserifyOpts([entry], fullPaths))
   var shouldMinify = !state.metadata.watch
+
+  // Lookup browsers to support in Babel.
+  var browsers = browserslist(null, { path: entry })
+  if (!browsers.length) browsers = defaultBrowsers
+
+  var babelPresets = [
+    [babelPresetEnv, {
+      targets: { browsers: browsers }
+    }]
+  ]
 
   if (state.metadata.watch) {
     b = watchify(b)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "brfs": "^1.4.4",
     "brotli": "^1.3.2",
     "browserify": "^16.0.0",
+    "browserslist": "^3.1.1",
     "buffer-graph": "^4.0.0",
     "clean-css": "^4.1.9",
     "concat-stream": "^1.6.0",


### PR DESCRIPTION
This is a 🙋 feature

Though browsers may be configured using `.babelrc` there's no way of sharing a browserslist config with e.g. autoprefixer or cssnext without duplicating the list. This makes it easier to consolidate which browsers to support.

The tests aren't very future proof as they'd yield false positives once all major browsers catch up with the specific features used in the test.

## Checklist
- [x] tests pass
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

## Semver Changes
Minor
