### PR TITLE
Only minify CSS when `watch: false`.

### DIFF
--- a/lib/graph-style.js
+++ b/lib/graph-style.js
@@ -17,15 +17,17 @@ function node (state, createEdge) {
   var bundle
 
   try {
-    bundle = purify(script, style, { minify: true })
+    bundle = purify(script, style)
   } catch (e) {
     this.emit('error', 'styles', 'purify-css', e)
   }
 
-  try {
-    bundle = clean.minify(bundle).styles
-  } catch (e) {
-    this.emit('error', 'styles', 'clean-css', e)
+  if (!state.metadata.watch) {
+    try {
+      bundle = clean.minify(bundle).styles
+    } catch (e) {
+      this.emit('error', 'styles', 'clean-css', e)
+    }
   }
 
   createEdge('bundle', Buffer.from(bundle))


### PR DESCRIPTION
Previously, CSS was always minified, thrice:

 - Once inside purify-css, only for the result to be discarded (PR here https://github.com/purifycss/purifycss/pull/196)
 - Once more inside purify-css because we set `minify: true`
 - Once using clean-css directly

With this patch, we only run clean-css directly once when using `bankai build`, and do not run it at all when using `bankai watch`. The one time in purify-css is still there until that PR is merged :woman_shrugging: 