### PR TITLE
Expose mime types on graph nodes, fixes #402

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ function Bankai (entry, opts) {
 
   // Insert nodes into the graph.
   this.graph.node('assets', assetsNode)
-  this.graph.node('documents', [ 'assets:list', 'manifest:color', 'manifest:description', 'styles:bundle', 'scripts:list', 'reload:bundle' ], documentNode)
+  this.graph.node('documents', [ 'assets:list', 'manifest:color', 'manifest:description', 'styles:bundle', 'scripts:bundle', 'reload:bundle' ], documentNode)
   this.graph.node('manifest', manifestNode)
   this.graph.node('scripts', scriptNode)
   this.graph.node('reload', reloadNode)

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ function Bankai (entry, opts) {
 
   // Insert nodes into the graph.
   this.graph.node('assets', assetsNode)
-  this.graph.node('documents', [ 'assets:list', 'manifest:color', 'manifest:description', 'styles:bundle', 'scripts:bundle', 'reload:bundle' ], documentNode)
+  this.graph.node('documents', [ 'assets:list', 'manifest:bundle', 'styles:bundle', 'scripts:bundle', 'reload:bundle' ], documentNode)
   this.graph.node('manifest', manifestNode)
   this.graph.node('scripts', scriptNode)
   this.graph.node('reload', reloadNode)

--- a/lib/graph-document.js
+++ b/lib/graph-document.js
@@ -78,7 +78,7 @@ function node (state, createEdge) {
     var body = content.body
     var selector = content.selector
 
-    var hasDynamicScripts = state.scripts.list.buffer.length > 0
+    var hasDynamicScripts = state.scripts.bundle.dynamicBundles.length > 0
 
     var html = head(language)
     var d = documentify(entry, html)
@@ -86,7 +86,7 @@ function node (state, createEdge) {
       viewportTag(),
       scriptTag({ hash: state.scripts.bundle.hash, base: base }),
       hasDynamicScripts && dynamicScriptsTag({
-        bundleNames: String(state.scripts.list.buffer).split(','),
+        bundleNames: state.scripts.bundle.dynamicBundles,
         scripts: state.scripts,
         base: base
       }),

--- a/lib/graph-document.js
+++ b/lib/graph-document.js
@@ -93,8 +93,8 @@ function node (state, createEdge) {
       preloadTag(),
       loadFontsTag({ fonts: fonts, base: base }),
       manifestTag({ base: base }),
-      descriptionTag({ description: String(state.manifest.description.buffer) }),
-      themeColorTag({ color: String(state.manifest.color.buffer) }),
+      descriptionTag({ description: state.manifest.bundle.description }),
+      themeColorTag({ color: state.manifest.bundle.color }),
       titleTag({ title: title })
     ].filter(Boolean)
     // TODO: twitter

--- a/lib/graph-document.js
+++ b/lib/graph-document.js
@@ -63,7 +63,9 @@ function node (state, createEdge) {
       var name = route
       if (name === '/') name = 'index'
       name = name + '.html'
-      createEdge(name, buf)
+      createEdge(name, buf, {
+        mime: 'text/html'
+      })
       done(null, buf)
     }
   }

--- a/lib/graph-manifest.js
+++ b/lib/graph-manifest.js
@@ -43,7 +43,9 @@ function node (state, createEdge, emit) {
       if (err) {
         createEdge('color', DEFAULT_COLOR)
         createEdge('description', DEFAULT_DESCRIPTION)
-        createEdge('bundle', DEFAULT_MANIFEST)
+        createEdge('bundle', DEFAULT_MANIFEST, {
+          mime: 'application/json'
+        })
         return
       }
 
@@ -56,7 +58,9 @@ function node (state, createEdge, emit) {
         debug('creating edges')
         createEdge('description', Buffer.from(res.value.description || ''))
         createEdge('color', Buffer.from(res.value.theme_color || '#fff'))
-        createEdge('bundle', Buffer.from(JSON.stringify(res.value)))
+        createEdge('bundle', Buffer.from(JSON.stringify(res.value)), {
+          mime: 'application/json'
+        })
       })
     })
   }

--- a/lib/graph-manifest.js
+++ b/lib/graph-manifest.js
@@ -4,15 +4,15 @@ var fs = require('fs')
 
 var utils = require('./utils')
 
-var DEFAULT_COLOR = Buffer.from('#fff')
-var DEFAULT_DESCRIPTION = Buffer.from('')
+var DEFAULT_COLOR = '#fff'
+var DEFAULT_DESCRIPTION = ''
 var DEFAULT_MANIFEST = Buffer.from(JSON.stringify({
   name: '',
   short_name: '',
   start_url: '/',
   display: 'minimal-ui',
   background_color: '#fff',
-  theme_color: '#fff'
+  theme_color: DEFAULT_COLOR
 }))
 
 var filenames = [
@@ -41,9 +41,9 @@ function node (state, createEdge, emit) {
     debug('parsing')
     utils.find(basedir, filenames, function (err, filename) {
       if (err) {
-        createEdge('color', DEFAULT_COLOR)
-        createEdge('description', DEFAULT_DESCRIPTION)
         createEdge('bundle', DEFAULT_MANIFEST, {
+          color: DEFAULT_COLOR,
+          description: DEFAULT_DESCRIPTION,
           mime: 'application/json'
         })
         return
@@ -56,9 +56,9 @@ function node (state, createEdge, emit) {
         if (res.err) return self.emit('error', 'manifest', 'JSON.parse', res.err)
 
         debug('creating edges')
-        createEdge('description', Buffer.from(res.value.description || ''))
-        createEdge('color', Buffer.from(res.value.theme_color || '#fff'))
         createEdge('bundle', Buffer.from(JSON.stringify(res.value)), {
+          color: res.value.theme_color || DEFAULT_COLOR,
+          description: res.value.description || DEFAULT_DESCRIPTION,
           mime: 'application/json'
         })
       })

--- a/lib/graph-reload.js
+++ b/lib/graph-reload.js
@@ -15,8 +15,12 @@ function node (state, createEdge) {
     var mapName = 'bankai-reload.js.map'
     exorcise(bundle, mapName, function (err, bundle, map) {
       if (err) return self.emit('error', 'reload', 'exorcise', err)
-      createEdge(mapName, map)
-      createEdge('bundle', bundle)
+      createEdge(mapName, map, {
+        mime: 'application/json'
+      })
+      createEdge('bundle', bundle, {
+        mime: 'application/javascript'
+      })
     })
   })
 }

--- a/lib/graph-script.js
+++ b/lib/graph-script.js
@@ -129,8 +129,12 @@ function node (state, createEdge) {
       var mapName = 'bundle.js.map'
       exorcise(bundle, mapName, function (err, bundle, map) {
         if (err) return self.emit('error', 'scripts', 'exorcise', err)
-        createEdge(mapName, Buffer.from(map))
-        createEdge('bundle', bundle)
+        createEdge(mapName, Buffer.from(map), {
+          mime: 'application/json'
+        })
+        createEdge('bundle', bundle, {
+          mime: 'application/javascript'
+        })
         createEdge('list', Buffer.from(dynamicBundles.join(',')))
         self.emit('progress', 'scripts', 100)
       })
@@ -140,7 +144,9 @@ function node (state, createEdge) {
   function exorciseDynamicBundle (bundleName) {
     var mapName = bundleName + '.map'
     return exorcist(concat({ encoding: 'buffer' }, function (map) {
-      createEdge(mapName, map)
+      createEdge(mapName, map, {
+        mime: 'application/json'
+      })
     }), mapName)
   }
 
@@ -148,7 +154,9 @@ function node (state, createEdge) {
     var edgeName = bundleName.replace(/\.js$/, '')
     var stream = concat({ encoding: 'buffer' }, function (bundle) {
       dynamicBundles.push(bundleName)
-      createEdge(edgeName, bundle)
+      createEdge(edgeName, bundle, {
+        mime: 'application/javascript'
+      })
 
       // Inform the main bundle about this file's full name.
       stream.emit('name', state.scripts[edgeName].hash.toString('hex').slice(0, 16) + '/' + bundleName)
@@ -158,7 +166,9 @@ function node (state, createEdge) {
 
   function bundleStyles () {
     return concat({ encoding: 'buffer' }, function (buf) {
-      createEdge('style', buf)
+      createEdge('style', buf, {
+        mime: 'text/css'
+      })
     })
   }
 }

--- a/lib/graph-script.js
+++ b/lib/graph-script.js
@@ -133,9 +133,9 @@ function node (state, createEdge) {
           mime: 'application/json'
         })
         createEdge('bundle', bundle, {
-          mime: 'application/javascript'
+          mime: 'application/javascript',
+          dynamicBundles: dynamicBundles
         })
-        createEdge('list', Buffer.from(dynamicBundles.join(',')))
         self.emit('progress', 'scripts', 100)
       })
     })

--- a/lib/graph-service-worker.js
+++ b/lib/graph-service-worker.js
@@ -44,7 +44,9 @@ function node (state, createEdge) {
     find(basedir, filenames, function (err, filename) {
       if (err) {
         state.metadata.serviceWorker = 'service-worker.js'
-        return createEdge('bundle', Buffer.from(''))
+        return createEdge('bundle', Buffer.from(''), {
+          mime: 'application/javascript'
+        })
       }
 
       // Expose what the original file name of the service worker was
@@ -83,8 +85,12 @@ function node (state, createEdge) {
           var mapName = 'bankai-service-worker.js.map'
           exorcise(bundle, mapName, function (err, bundle, map) {
             if (err) return self.emit('error', 'service-worker', 'exorcise', err)
-            createEdge(mapName, map)
-            createEdge('bundle', bundle)
+            createEdge(mapName, map, {
+              mime: 'application/json'
+            })
+            createEdge('bundle', bundle, {
+              mime: 'application/javascript'
+            })
           })
         })
       }

--- a/lib/graph-style.js
+++ b/lib/graph-style.js
@@ -28,7 +28,9 @@ function node (state, createEdge) {
     this.emit('error', 'styles', 'clean-css', e)
   }
 
-  createEdge('bundle', Buffer.from(bundle))
+  createEdge('bundle', Buffer.from(bundle), {
+    mime: 'text/css'
+  })
 }
 
 function createCleanCssOptions () {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "brotli": "^1.3.2",
     "browserify": "^16.0.0",
     "browserslist": "^3.1.1",
-    "buffer-graph": "^4.0.0",
+    "buffer-graph": "^4.1.0",
     "clean-css": "^4.1.9",
     "concat-stream": "^1.6.0",
     "css-extract": "^1.2.0",


### PR DESCRIPTION
This depends on https://github.com/yoshuawuyts/buffer-graph/pull/11

Graph nodes now get a `.mime` property in addition to `.buffer` and `.hash`. Fastify can use this to set the content-type header.