### PR TITLE
Fix assets list assigned an empty buffer

### DIFF
--- a/lib/graph-assets.js
+++ b/lib/graph-assets.js
@@ -36,7 +36,7 @@ function node (state, createEdge) {
 
   tracker.on('change', function () {
     var list = tracker.list()
-    createEdge('list', Buffer.from(list))
+    createEdge('list', Buffer.from(list.join()))
   })
 
   tracker.on('progress', function (progress) {

--- a/lib/graph-assets.js
+++ b/lib/graph-assets.js
@@ -36,7 +36,7 @@ function node (state, createEdge) {
 
   tracker.on('change', function () {
     var list = tracker.list()
-    createEdge('list', Buffer.from(list.join()))
+    createEdge('list', Buffer.from(list.join(',')))
   })
 
   tracker.on('progress', function (progress) {


### PR DESCRIPTION
This is a 🐛 bug fix

I noticed the font preload wasn't working because `Buffer.from(<array>)` would yield an empty buffer.

## Checklist
- [x] tests pass

## Semver Changes
Patch