### PR TITLE
Exclude all choo routes with partials

### DIFF
--- a/ssr/choo.js
+++ b/ssr/choo.js
@@ -9,8 +9,9 @@ module.exports.is = function (app) {
 
 module.exports.listRoutes = function (app) {
   var keys = getAllRoutes(app.router.router)
-  if (keys['/:']) delete keys['/:'] // Server rendering partials is tricky.
-  return Object.keys(keys)
+  return Object.keys(keys).filter(function (key) {
+    return !/\/:/.test(key) // Server rendering partials is tricky.
+  })
 }
 
 // Do a double render pass - the first time around we wait for promises to be


### PR DESCRIPTION
This is a 🐛 bug fix

Only top level partial routes were being filtered out. This excludes all routes with a partial in them.

## Checklist
- [x] tests pass

## Semver Changes
Patch