### PR TITLE
Fix inlining critical css

### DIFF
--- a/lib/graph-document.js
+++ b/lib/graph-document.js
@@ -125,16 +125,16 @@ function node (state, createEdge) {
 
       d.transform(addToHead, header.join(''))
 
+      d.transform(insertApp, {
+        selector: selector,
+        body: body
+      })
+
       if (state.styles.bundle.buffer.length) {
         d.transform(criticalTransform, { css: state.styles.bundle.buffer })
       }
 
       d.transform(addToHead, styleTag({ hash: state.styles.bundle.hash, base: base }))
-
-      d.transform(insertApp, {
-        selector: selector,
-        body: body
-      })
 
       function complete (buf) { done(null, buf) }
 


### PR DESCRIPTION
This a 🐛 bug fix

## Checklist
- [x] tests pass
- [x] tests and/or benchmarks are included

## Context

https://github.com/choojs/bankai/pull/414 inserts the server rendered
app at the very end of the transform chain. The critical CSS inline
transform ran _before_ the server rendered app was inserted, so it did
not catch any selectors that were used in the app.

This patch moves the critical CSS transform to the end so that it works
on the entire server rendered app.

## Semver Changes
Patch
