### PR TITLE
Enable node debugger with debug flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ a project setup from scratch :sparkles:.
 
   Options:
 
-    -d, --debug       output lots of logs
+    -d, --debug       start node debugger
     -h, --help        print usage
     -q, --quiet       don't output any logs
     -v, --version     print version

--- a/bin.js
+++ b/bin.js
@@ -20,7 +20,7 @@ var USAGE = `
 
   Options:
 
-    -d, --debug       output lots of logs
+    -d, --debug       start node debugger
     -h, --help        print usage
     -q, --quiet       don't output any logs
     -v, --version     print version
@@ -60,18 +60,18 @@ var CONFIG_USAGE = `
   ${clr('Configuration', 'bold')}
 
 
-  Bankai is built on top of compilers for scripts, styles and documents. 
-  Each of them can be configured by adding a field to your project's 
+  Bankai is built on top of compilers for scripts, styles and documents.
+  Each of them can be configured by adding a field to your project's
   package.json file.
 
-  These three fields are, respectively: ${clr('"browserify"', 'cyan')}, ${clr('"sheetify"', 'cyan')} and 
+  These three fields are, respectively: ${clr('"browserify"', 'cyan')}, ${clr('"sheetify"', 'cyan')} and
   ${clr('"documentify"', 'cyan')}. Each one should have a configuration object as it's value.
 
   There is currently one possible configuration field: "transform".
 
   It can be one of either:
 
-  1. An array of transform names. 
+  1. An array of transform names.
        ie:  ${clr('[ "vueify" ]', 'cyan')}
   2. An array of tuples transform name + configuration object.
        ie: ${clr('[[ "vueify", { "sass": { "includePaths": [ "src/assets/css" ] } } ]]', 'cyan')}
@@ -103,7 +103,8 @@ var argv = minimist(process.argv.slice(2), {
     help: 'h',
     quiet: 'q',
     version: 'v',
-    base: 'b'
+    base: 'b',
+    debug: 'd'
   },
   boolean: [
     'help',
@@ -120,6 +121,11 @@ var argv = minimist(process.argv.slice(2), {
     if (!path.isAbsolute(entry)) entry = path.join(process.cwd(), entry)
   } else {
     entry = process.cwd()
+  }
+
+  if (argv.debug) {
+    if (typeof argv.debug === 'number') process.debugPort = argv.debug
+    process.kill(process.pid, 'SIGUSR1')
   }
 
   if (argv.help) {


### PR DESCRIPTION
This is a 🙋 feature

Debugging an app running on bankai (or bankai itself, for that matter) with just `console.log` isn't the most ergonomic experience and the `debug` option wasn't doing anything anyway (one has to set the `DEBUG` env variable to enable logs). 

This adds the `debug` option which signals node to start listening for debuggers, optionally on a specific port. Though the port option isn't working for me, supposedly this is how it's intended to work (https://nodejs.org/api/process.html#process_process_debugport).

## Checklist
- [x] tests pass
- [x] documentation is changed or added

## Semver Changes
Minor