### PR TITLE
Asynchronously init choo stores before list routes

### DIFF
--- a/lib/graph-document.js
+++ b/lib/graph-document.js
@@ -31,16 +31,19 @@ function node (state, createEdge) {
     return self.emit('error', 'documents', entry, ssr.error)
   }
 
-  // TODO: don't pass a callback here - super hard to reason about. Find a
-  // different way instead. Perhaps a prototype with methods on it instead?
-  self.emit('ssr', { success: true, renderRoute: documentifyRoute })
-
   var fonts = extractFonts(state.assets)
-  var list = ssr.routes
 
-  mapLimit(list, WRITE_CONCURRENCY, documentifyRoute, function (err) {
-    if (err) return self.emit(err)
-    createEdge('list', Buffer.from(list.join(',')))
+  ssr.listRoutes(function (err, list) {
+    if (err) return self.emit('ssr', { success: false, error: ssr.error })
+
+    // TODO: don't pass a callback here - super hard to reason about. Find a
+    // different way instead. Perhaps a prototype with methods on it instead?
+    self.emit('ssr', { success: true, renderRoute: documentifyRoute })
+
+    mapLimit(list, WRITE_CONCURRENCY, documentifyRoute, function (err) {
+      if (err) return self.emit(err)
+      createEdge('list', Buffer.from(list.join(',')))
+    })
   })
 
   function documentifyRoute (route, done) {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   "devDependencies": {
     "a-module-with-babelrc": "^1.0.0",
     "assert-html": "^1.1.5",
-    "choo": "^6.8.0",
+    "choo": "^6.10.3",
     "choo-devtools": "^2.3.3",
     "choo-service-worker": "^2.4.0",
     "rimraf": "^2.6.2",

--- a/ssr/index.js
+++ b/ssr/index.js
@@ -11,7 +11,6 @@ module.exports = class ServerRender {
     this.app = this._requireApp(this.entry)
 
     this.appType = this._getAppType(this.app)
-    this.routes = this._listRoutes(this.app)
     this.entry = entry
     this.error = null
 
@@ -34,6 +33,11 @@ module.exports = class ServerRender {
     }
   }
 
+  listRoutes (cb) {
+    if (this.appType === 'choo') return choo.listRoutes(this.app, cb)
+    return cb(null, ['/'])
+  }
+
   _getAppType (app) {
     if (choo.is(app)) return 'choo'
     else return 'default'
@@ -50,11 +54,6 @@ module.exports = class ServerRender {
         this.error = ssrError
       }
     }
-  }
-
-  _listRoutes (app) {
-    if (this.appType === 'choo') return choo.listRoutes(this.app)
-    return ['/']
   }
 }
 


### PR DESCRIPTION
This is a 🙋 feature

## Checklist
- [x] tests pass

## Context

This allows for asynchronously registering routes using choo stores. There's been a lot of talk lately about async render in choo (https://github.com/choojs/choo/pull/646) and I believe we should look into async initialization at the same time. This PR would allow us to start experimenting with that without having to commit to breaking changes in the API.

Here's an example choo store which, when registered, adds a promise to the `_experimental_prefetch` array which resolves once it has fetched all posts from some CMS and added them as routes to the app. These routes are included in static builds and enjoy proper SSR.

```javascript
module.exports = store

function store (state, emitter, app) {
  state._experimental_prefetch.push(
    getPostsFromCMS().then(function (posts) {
      posts.forEach(function (post) {
        // add route for each post
        app.route(`/posts/${post.slug}`, require('../views/post'))
      })
    })
  )
}
```

This depends on https://github.com/choojs/choo/pull/649 which allows for custom state to be passed into stores.

## Semver Changes
Minor