### PR TITLE
Fix font preload path

### DIFF
--- a/lib/graph-document.js
+++ b/lib/graph-document.js
@@ -35,7 +35,7 @@ function node (state, createEdge) {
   // different way instead. Perhaps a prototype with methods on it instead?
   self.emit('ssr', { success: true, renderRoute: documentifyRoute })
 
-  var fonts = extractFonts(state.assets)
+  var fonts = extractFonts(state.assets, utils.dirname(entry))
   var list = ssr.routes
 
   mapLimit(list, WRITE_CONCURRENCY, documentifyRoute, function (err) {
@@ -187,8 +187,7 @@ function styleTag (opts) {
 
 function loadFontsTag (opts) {
   return opts.fonts.reduce(function (html, font) {
-    if (!path.isAbsolute(font)) font = (opts.base || '') + '/' + font
-    return html + `<link rel="preload" as="font" crossorigin href="${font}">`
+    return html + `<link rel="preload" as="font" crossorigin href="${opts.base || ''}/${font}">`
   }, '')
 }
 
@@ -250,16 +249,13 @@ function insertApp (opts) {
 }
 
 // Specific to the document node's layout
-function extractFonts (state) {
+function extractFonts (state, root) {
   var list = String(state.list.buffer).split(',')
 
   var res = list.filter(function (font) {
-    var extname = path.extname(font)
-
-    return extname === '.woff' ||
-      extname === '.woff2' ||
-      extname === '.eot' ||
-      extname === '.ttf'
+    return /^\.(woff2?|eot|ttf)$/.test(path.extname(font))
+  }).map(function (font) {
+    return path.relative(root, font)
   })
 
   return res


### PR DESCRIPTION
This is a 🐛 bug fix

## Checklist
- [x] tests pass

## Context
Font preload paths were being resolved to their absolute path on disk. This fixes that by resolving their path as relative to app entry file (and optional base dir).

```diff
- <link rel="preload" as="font" crossorigin="" href="/Users/carl/site.com/assets/font.woff">
+ <link rel="preload" as="font" crossorigin="" href="/assets/font.woff">
```

## Semver Changes
Patch