### PR TITLE
Disable Babel modules transform for dependencies

### DIFF
--- a/lib/graph-script.js
+++ b/lib/graph-script.js
@@ -46,12 +46,6 @@ function node (state, createEdge) {
   var browsers = browserslist(null, { path: entry })
   if (!browsers.length) browsers = defaultBrowsers
 
-  var babelPresets = [
-    [babelPresetEnv, {
-      targets: { browsers: browsers }
-    }]
-  ]
-
   if (state.metadata.watch) {
     b = watchify(b)
     debug('watching ' + entry)
@@ -64,20 +58,34 @@ function node (state, createEdge) {
   b.ignore('sheetify/insert')
   b.transform(sheetify)
   b.transform(glslify)
+
   if (state.metadata.babelifyDeps) {
     // Dependencies should be transformed, but their .babelrc should be ignored.
     b.transform(tfilter(babelify, { include: /node_modules/ }), {
       global: true,
       babelrc: false,
-      presets: babelPresets
+      presets: [
+        [babelPresetEnv, {
+          // browserify resolves the commonjs version of modules anyway,
+          // and the modules transform in babel-preset-env rewrites top level `this`
+          // to `undefined` which breaks some modules (underscore, cuid, ...)
+          modules: false,
+          targets: { browsers: browsers }
+        }]
+      ]
     })
   }
   // In our own code, .babelrc files should be used.
   b.transform(tfilter(babelify, { exclude: /node_modules/ }), {
     global: true,
     babelrc: true,
-    presets: babelPresets
+    presets: [
+      [babelPresetEnv, {
+        targets: { browsers: browsers }
+      }]
+    ]
   })
+
   b.transform(brfs, { global: true })
   b.transform(yoyoify, { global: true })
 


### PR DESCRIPTION
This a 🐛 bug fix

The Babel modules transform turns top level `this` into undefined. This
causes issues with some libraries that expect `this` to refer to the
global object (or at least expect it to exist). See #423 for an example.

Because browserify looks for the package.json `main` key, which should
not contain ES modules code, it should be safe to just disable the
modules transform.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [x] tests and/or benchmarks are included

## Context
#423 
And a different take on #422

## Semver Changes
Patch
