### PR TITLE
Add source map support for stack traces

### DIFF
--- a/lib/graph-script.js
+++ b/lib/graph-script.js
@@ -76,7 +76,9 @@ function node (state, createEdge) {
     babelrc: true,
     presets: babelPresets
   })
-  b.transform(brfs, { global: true })
+  b.transform(tfilter(brfs, { exclude: /source-map-support/ }), {
+    global: true
+  })
   b.transform(yoyoify, { global: true })
 
   if (!fullPaths) b.plugin(cssExtract, { out: bundleStyles })
@@ -109,6 +111,7 @@ function node (state, createEdge) {
       NODE_ENV: 'development'
     }, process.env)
     b.transform(envify(env), { global: true })
+    b.add(require.resolve('source-map-support/register'))
   }
 
   bundleScripts()

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "send": "^0.16.1",
     "server-router": "^6.0.0",
     "sheetify": "^7.1.0",
+    "source-map-support": "^0.5.4",
     "split-require": "^3.0.1",
     "split2": "^2.2.0",
     "strip-ansi": "^4.0.0",


### PR DESCRIPTION
This is a 🙋 feature

Add support for stack traces (in Chrome) using [source-map-support](https://github.com/evanw/node-source-map-support).

## Checklist
- [x] tests pass

## Context
Error stack traces would reference line numbers in the bundled javascript making it a hassle to track down where an error was thrown.

### Before
```
Error: Wut?
    at home (https://localhost:8080/a5a979a6e87a19a2/bundle.js:12343:9)
    at Choo._handler (https://localhost:8080/a5a979a6e87a19a2/bundle.js:1014:53)
    at Choo._prerender (https://localhost:8080/a5a979a6e87a19a2/bundle.js:4520:18)
    at Choo.start (https://localhost:8080/a5a979a6e87a19a2/bundle.js:4424:21)
    at https://localhost:8080/a5a979a6e87a19a2/bundle.js:4462:24
```

### After
```
Error: Wut?
    at home (https://localhost:8080/87ff141e6fbaf70d/views/home.js:32:1)
    at Choo._handler (https://localhost:8080/87ff141e6fbaf70d/components/view/index.js:27:1)
    at Choo._prerender (https://localhost:8080/87ff141e6fbaf70d/node_modules/choo/index.js:241:1)
    at Choo.start (https://localhost:8080/87ff141e6fbaf70d/node_modules/choo/index.js:145:1)
    at https://localhost:8080/87ff141e6fbaf70d/node_modules/choo/index.js:183:1
```

*Note: `brfs` couldn't handle source-map-support checks for methods on `fs` so I had to exclude it from the transform.*

## Semver Changes
Minor