### PR TITLE
Fix builds breaking when assets contained file without extension, such as .DS_Store

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,13 +4,8 @@ var Debug = require('debug')
 var path = require('path')
 
 // Figure out what directory the file is in.
-// Does nothing if a directory is passed.
 exports.dirname = function (pathname) {
-  if (!path.extname(pathname)) {
-    return pathname
-  } else {
-    return path.dirname(pathname)
-  }
+  return path.dirname(pathname)
 }
 
 // Figure out what directory the file is in.

--- a/test/script.js
+++ b/test/script.js
@@ -28,6 +28,26 @@ tape('run a JS pipeline', function (assert) {
   })
 })
 
+tape('use a folder as an entry point', function (assert) {
+  assert.plan(2)
+  var file = dedent`
+    console.log(1 + 1)
+  `
+
+  var dirname = 'js-pipeline-' + (Math.random() * 1e4).toFixed()
+  var tmpDirname = path.join(os.tmpdir(), dirname)
+  var tmpScriptname = path.join(tmpDirname, 'index.js')
+  fs.mkdirSync(tmpDirname)
+  fs.writeFileSync(tmpScriptname, file)
+
+  var compiler = bankai(tmpDirname, { watch: false })
+  compiler.scripts('bundle.js', function (err, res) {
+    assert.error(err, 'no error writing script')
+    assert.notEqual(res.buffer.toString('utf8').indexOf('console.log'), -1, 'contains js')
+    rimraf.sync(tmpDirname)
+  })
+})
+
 tape('return an error if an incorrect script is selected', function (assert) {
   assert.plan(1)
   var file = dedent`


### PR DESCRIPTION
This is a 🐛 bug fix.

Bankai build has been brittle for me since asset directory copying has been stopping silently on errors. I haven't been able to fix the swallowing errors, but I tracked down a big source of indeterminacy.

Asset directory copying previously aborted without an error if Bankai encountered a file without an extension. `.DS_Store` fit the bill. So opening an asset directory in OSX Finder would cause builds to go awry 😱.

This fixes the issue (and I added tests to make sure it doesn't break passing a bare directory to the cli). Ultimately, `bankai build` needs more tests...

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [x] tests and/or benchmarks are included

## Context
<!-- Is this related to any GitHub issue(s)? -->

## Semver Changes
<!-- Which semantic version change would you recommend? -->
