### PR TITLE
support content and public dirs in http

### DIFF
--- a/http.js
+++ b/http.js
@@ -118,9 +118,9 @@ function start (entry, opts) {
     })
   })
 
-  router.route(/^\/assets\/([^?]*)(\?.*)?$/, function (req, res, params) {
-    var prefix = 'assets' // TODO: also accept 'content'
-    var name = prefix + '/' + params[1]
+  router.route(/^\/(assets|content|public)\/([^?]*)(\?.*)?$/, function (req, res, params) {
+    var prefix = params[1] // asset dir
+    var name = prefix + '/' + params[2]
     compiler.assets(name, function (err, filename) {
       if (err) {
         res.statusCode = 404

--- a/test/http.js
+++ b/test/http.js
@@ -30,11 +30,12 @@ function setup () {
 
   var dirname = 'manifest-pipeline-' + (Math.random() * 1e4).toFixed()
   tmpDirname = path.join(os.tmpdir(), dirname)
+  var contentDirname = path.join(tmpDirname, 'content')
   var assetDirname = path.join(tmpDirname, 'assets')
   var assetSubdirname = path.join(assetDirname, 'images')
 
   tmpScriptname = path.join(tmpDirname, 'index.js')
-  var tmpFilename = path.join(assetDirname, 'file.txt')
+  var tmpFilename = path.join(contentDirname, 'file.txt')
   var tmpAssetJsFilename = path.join(assetDirname, 'file.js')
   var tmpAssetCssFilename = path.join(assetDirname, 'file.css')
   var tmpJsonFilename = path.join(assetDirname, 'file.json')
@@ -42,6 +43,7 @@ function setup () {
   var tmpJpgSubFilename = path.join(assetSubdirname, 'file.jpg')
 
   fs.mkdirSync(tmpDirname)
+  fs.mkdirSync(contentDirname)
   fs.mkdirSync(assetDirname)
   fs.mkdirSync(assetSubdirname)
   fs.writeFileSync(tmpScriptname, script)
@@ -74,8 +76,8 @@ tape('should route urls appropriately', function (assert) {
     '/bundle.js?cache=busted',
     '/bundle.css',
     '/bundle.css?cache=busted',
-    '/assets/file.txt',
-    '/assets/file.txt?cache=busted',
+    '/content/file.txt',
+    '/content/file.txt?cache=busted',
     '/assets/file.json',
     '/assets/file.css',
     '/assets/file.css?cache=busted',


### PR DESCRIPTION
This is a 🐛.

Although `content` and `public` are supported asset directories by the rest of the build pipeline, the `http` server throws 404s.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [x] tests and/or benchmarks are included

## Context
This looks like it was broken by https://github.com/choojs/bankai/pull/396

## Semver Changes
minor