### PR TITLE
Replace findup by @choojs/findup

### DIFF
--- a/lib/graph-service-worker.js
+++ b/lib/graph-service-worker.js
@@ -1,6 +1,6 @@
 var debug = require('debug')('bankai.graph-service-worker')
+var findup = require('@choojs/findup')
 var assert = require('assert')
-var findup = require('findup')
 var path = require('path')
 
 var browserify = require('browserify')

--- a/lib/is-electron-project.js
+++ b/lib/is-electron-project.js
@@ -1,5 +1,5 @@
 var explain = require('explain-error')
-var findup = require('findup')
+var findup = require('@choojs/findup')
 var path = require('path')
 var fs = require('fs')
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,5 @@
 var recursiveWatch = require('recursive-watch')
-var findup = require('findup')
+var findup = require('@choojs/findup')
 var Debug = require('debug')
 var path = require('path')
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "keywords": [],
   "dependencies": {
+    "@choojs/findup": "^0.2.0",
     "ansi-diff": "^1.0.10",
     "ansi-escape-sequences": "^4.0.0",
     "async-collection": "^1.0.1",
@@ -38,7 +39,6 @@
     "exorcist": "^1.0.0",
     "explain-error": "^1.0.4",
     "fast-json-parse": "^1.0.3",
-    "findup": "^0.1.5",
     "flush-write-stream": "^1.0.2",
     "fs-compare": "^0.0.4",
     "get-port": "^3.2.0",


### PR DESCRIPTION
This is a 🐛 bug fix

@choojs/findup is a fork of findup that removes the `colors` dependency.
`colors` adds lots of properties to the String prototype, which was
causing big slowdowns in bankai. About 300ms was spent calling `colors`
getters that were never expected to be there (mostly by the CSS parser).

<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->


<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass

## Context
![profile screenie](https://i.imgur.com/jIHp4yJ.png)

## Semver Changes
Patch
