### PR TITLE
Add quotes around theme-color `content`.

### DIFF
--- a/lib/graph-document.js
+++ b/lib/graph-document.js
@@ -213,7 +213,7 @@ function descriptionTag (opts) {
 
 function themeColorTag (opts) {
   return `
-    <meta name="theme-color" content=${opts.color}>
+    <meta name="theme-color" content="${opts.color}">
   `.replace(/\n +/g, '')
 }
 


### PR DESCRIPTION
This is a 🐛 bug fix

Probably missed this in the mime types PR. That moved the theme color
onto metadata, without surrounding it with quotes first.

Before:

    <meta name="theme-color" content=#fff>

After:

    <meta name="theme-color" content="#fff">

## Checklist
- [x] tests pass

## Semver
Patch