### PR TITLE
Fixed + more consistent basedir handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,9 +44,7 @@ function Bankai (entry, opts) {
 
   // Initialize data structures.
   var key = Buffer.from('be intolerant of intolerance')
-  this.dirname = path.basename(entry).includes('.') // The base directory.
-    ? utils.dirname(entry)
-    : entry
+  this.dirname = path.extname(entry) === '' ? entry : utils.dirname(entry) // The base directory.
   this.queue = queue(methods) // The queue caches requests until ready.
   this.graph = graph(key) // The graph manages relations between deps.
 

--- a/index.js
+++ b/index.js
@@ -44,7 +44,9 @@ function Bankai (entry, opts) {
 
   // Initialize data structures.
   var key = Buffer.from('be intolerant of intolerance')
-  this.dirname = utils.dirname(entry) // The base directory.
+  this.dirname = path.basename(entry).includes('.') // The base directory.
+    ? utils.dirname(entry)
+    : entry
   this.queue = queue(methods) // The queue caches requests until ready.
   this.graph = graph(key) // The graph manages relations between deps.
 

--- a/index.js
+++ b/index.js
@@ -44,6 +44,9 @@ function Bankai (entry, opts) {
 
   // Initialize data structures.
   var key = Buffer.from('be intolerant of intolerance')
+  // TODO maybe use fs.stat here to check if it's a directory?
+  // That would be best but we may have to do a sync call, because graph nodes depend on this
+  // value being available immediately, which is less great.
   this.dirname = path.extname(entry) === '' ? entry : utils.dirname(entry) // The base directory.
   this.queue = queue(methods) // The queue caches requests until ready.
   this.graph = graph(key) // The graph manages relations between deps.

--- a/lib/graph-assets.js
+++ b/lib/graph-assets.js
@@ -21,7 +21,7 @@ var dirs = [
 module.exports = node
 
 function node (state, createEdge) {
-  var basedir = utils.dirname(state.metadata.entry)
+  var basedir = state.metadata.dirname
   var self = this
 
   if (state.tracker) return

--- a/lib/graph-assets.js
+++ b/lib/graph-assets.js
@@ -1,5 +1,4 @@
 var trackDir = require('./track-dir')
-var utils = require('./utils')
 var path = require('path')
 
 var dirs = [

--- a/lib/graph-manifest.js
+++ b/lib/graph-manifest.js
@@ -22,7 +22,7 @@ var filenames = [
 module.exports = node
 
 function node (state, createEdge, emit) {
-  var basedir = utils.dirname(state.metadata.entry)
+  var basedir = state.metadata.dirname
   var self = this
 
   if (state.metadata.watch && !state.metadata.watchers.manifest) {

--- a/lib/graph-service-worker.js
+++ b/lib/graph-service-worker.js
@@ -26,7 +26,7 @@ function node (state, createEdge) {
 
   assert.equal(typeof entry, 'string', 'bankai.service-worker: state.metadata.entries should be type string')
 
-  var basedir = utils.dirname(state.metadata.entry)
+  var basedir = state.metadata.dirname
 
   if (state.metadata.watch && !state.metadata.watchers.serviceWorker) {
     state.metadata.watchers.serviceWorker = true

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bankai": "bin.js"
   },
   "scripts": {
-    "build": "./bin.js build example",
+    "build": "./bin.js build example dist",
     "test": "standard && node test",
     "start": "NODE_NO_WARNINGS=1 ./bin.js start example",
     "debug": "DEBUG='*' ./bin.js start -q example"

--- a/test/assets.js
+++ b/test/assets.js
@@ -23,7 +23,7 @@ tape('run an asset pipeline', function (assert) {
     hello planet
   `
 
-  var dirname = 'manifest-pipeline-' + (Math.random() * 1e4).toFixed()
+  var dirname = 'asset-pipeline-' + (Math.random() * 1e4).toFixed()
   tmpDirname = path.join(os.tmpdir(), dirname)
   var assetDirname = path.join(os.tmpdir(), dirname, 'assets')
 
@@ -49,5 +49,45 @@ tape('run an asset pipeline', function (assert) {
   compiler.assets('assets/file.txt', function (err, buf) {
     assert.error(err, 'no error reading file')
     assert.ok(buf, 'buffer is fine fine fine')
+  })
+})
+
+tape('use correct asset dir when entry point is a dir', function (assert) {
+  assert.on('end', cleanup)
+
+  var script = dedent`
+    document.body.textContent = 'Whatever'
+  `
+  var file = dedent`
+    a file!!!
+  `
+
+  var dirname = 'asset-pipeline-' + (Math.random() * 1e4).toFixed()
+  tmpDirname = path.join(os.tmpdir(), dirname)
+  var assetDirname = path.join(os.tmpdir(), dirname, 'assets')
+
+  var tmpScriptname = path.join(tmpDirname, 'index.js')
+  var tmpFilename = path.join(assetDirname, 'file.txt')
+
+  fs.mkdirSync(tmpDirname)
+  fs.mkdirSync(assetDirname)
+  fs.writeFileSync(tmpScriptname, script)
+  fs.writeFileSync(tmpFilename, file)
+
+  var compiler = bankai(tmpDirname, { watch: false })
+
+  compiler.on('error', function (name, sub, err) {
+    assert.error(err, 'no error')
+  })
+
+  compiler.assets('assets/file.txt', function (err, buf) {
+    assert.error(err, 'no error reading file')
+    assert.ok(buf, 'buffer is fine fine fine')
+    assert.equal(buf, tmpFilename)
+  })
+
+  compiler.on('change', function (nodeName, second) {
+    if (nodeName !== 'documents' || second !== 'list') return
+    assert.end()
   })
 })


### PR DESCRIPTION
This is a 🐛 bug fix

When the entry point is given as a directory, the build destination
`dist` and asset paths would be calculated relative to the parent
directory. With this patch, the default build destination is `./dist`
relative to the entry point file, and assets are served from `./assets`
relative to the entry point file.

Ensures that these:
```
bankai build example/index.js
bankai build example
```
both do the same thing.

## Checklist

- [x] tests pass
- [x] tests and/or benchmarks are included

## Context
```
14:14 < louisc> I'm having an issue with bankai whereby if I try and
  access a file in the `assets` directory, bankai will try and serve
  the asset from the wrong filepath
14:15 < louisc> for example, if I'm running bankai from ~/dev/mywebsite,
  it will try and load assets from ~/dev/assets, rather than
  ~/dev/mywebsite/assets
14:15 < louisc> I'm using v9.10.7
14:16 < louisc> I'm wondering if this is to do with the change in
  9.10.4 that dealt with asset pathing?
14:17 < louisc> cc benlyn goto-bus-stop
14:18 < goto-bus-stop> louisc: o, possibly
14:19 < goto-bus-stop> louisc: does it work correctly if you do
  `bankai start ~/dev/mywebsite/index.js` instead?
14:19 < louisc> goto-bus-stop: yes
```

## Semver
Patch