### PR TITLE
deps: add missing dependency `resolve`

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "purify-css": "^1.2.6",
     "recursive-readdir": "^2.2.1",
     "recursive-watch": "^1.1.3",
+    "resolve": "^1.7.1",
     "selfsigned": "^1.10.2",
     "send": "^0.16.1",
     "server-router": "^6.0.0",


### PR DESCRIPTION
This is a 🐛 bug fix.

Found while using `pnpm` - an alternative package manager that is more strict
during resolving dependency chains. Guessing it got pulled somehow using when `npm`.

We require `resolve` in [`lib/graph-document.js`](https://github.com/choojs/bankai/blob/master/lib/graph-document.js#L5) but is missing from `packages.json`.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Semver Changes
Patch or minor. 