### PR TITLE
Fix outputting dynamic bundles, fixes #472

### DIFF
--- a/lib/cmd-build.js
+++ b/lib/cmd-build.js
@@ -48,7 +48,7 @@ function build (entry, outdir, opts) {
       var stepName = nodeName + ':' + edgeName
       if (stepName === 'assets:list') writeAssets('assets')
       if (stepName === 'documents:list') writeDocuments('documents')
-      if (stepName === 'scripts:list') writeScripts('scripts')
+      if (stepName === 'scripts:bundle') writeScripts('scripts')
       if (stepName === 'service-worker:bundle') {
         var filename = compiler.graph.metadata.serviceWorker
         compiler.serviceWorker(writeSimple(filename, 'service-worker'))
@@ -103,9 +103,8 @@ function build (entry, outdir, opts) {
     }
 
     function writeScripts (step) {
-      var node = compiler.graph.data[step].list
-      var list = String(node.buffer)
-      list = list.length ? list.split(',') : []
+      var node = compiler.graph.data[step].bundle
+      var list = node.dynamicBundles || []
       async.mapLimit(list, 3, iterator, function (err) {
         if (err) return log.error(err)
         completed(step)


### PR DESCRIPTION
This is a 🐛 bug fix

When #443 was merged, it moved the list of dynamic bundle names to a
metadata property on the `scripts:bundle` node. However, the `bankai
build` command was never updated to match.


## Checklist
- [ ] tests pass
- [ ] tests and/or benchmarks are included

We don't have tests yet for the build and it's tricky. Guess we'd just
need to kick off a child process

## Context
#472

## Semver Changes
Patch