### PR TITLE
Improve syntax error messages

### DIFF
--- a/lib/tty-error.js
+++ b/lib/tty-error.js
@@ -8,11 +8,11 @@ var cwd = process.cwd()
 module.exports = ttyError
 
 function ttyError (src, sub, err) {
-  if (!err.filename || !err.loc) return err
+  var longFilename = err.filename || err.fileName
+  if (!longFilename || !getErrorLocation(err)) return err
 
-  var longFilename = err.filename
   var filename = path.relative(cwd, longFilename)
-  var loc = err.loc
+  var loc = getErrorLocation(err)
   var line = loc.line
   var col = loc.column + 1
 
@@ -20,7 +20,7 @@ function ttyError (src, sub, err) {
   var padLen = lineNum.length
   var empty = padLeft('|', padLen + 1)
   var arrow = padLeft('--> ', padLen + 4 - 1)
-  var syntaxError = padLeft('', col) + '^ Syntax Error'
+  var syntaxError = padLeft('', col) + '^ ' + getErrorMessage(err)
 
   try {
     var file = fs.readFileSync(longFilename, 'utf8')
@@ -64,4 +64,28 @@ function pad (len, char) {
   var res = ''
   while (res.length < len) res += char
   return res
+}
+
+function getErrorLocation (err) {
+  if (err.loc) return err.loc
+  if (typeof err.line === 'number' && typeof err.column === 'number') {
+    return {
+      line: err.line,
+      column: err.column
+    }
+  }
+  return null
+}
+
+function getErrorMessage (err) {
+  var loc = getErrorLocation(err)
+  var message = err.message
+    // strip file names
+    .replace(/^.*?:|while parsing file:.*?$/g, '')
+    // strip position in file
+    .replace('(' + loc.line + ':' + loc.column + ')', '')
+    // same, but for typescript
+    .replace('(' + loc.line + ',' + loc.column + ')', '')
+
+  return message || 'Syntax Error'
 }


### PR DESCRIPTION
Extracted from #406.

Previously this would only show "Syntax Error":
![image](https://user-images.githubusercontent.com/1006268/35732739-dcfaf4f4-081a-11e8-8de9-46e0a661c239.png)