### PR TITLE
🐛 Unify service-worker env url format

### DIFF
--- a/lib/graph-service-worker.js
+++ b/lib/graph-service-worker.js
@@ -1,5 +1,4 @@
 var debug = require('debug')('bankai.graph-service-worker')
-var findup = require('@choojs/findup')
 var assert = require('assert')
 var path = require('path')
 
@@ -41,7 +40,7 @@ function node (state, createEdge) {
   parse()
 
   function parse () {
-    find(basedir, filenames, function (err, filename) {
+    utils.find(basedir, filenames, function (err, filename) {
       if (err) {
         state.metadata.serviceWorker = 'service-worker.js'
         return createEdge('bundle', Buffer.from(''), {
@@ -106,16 +105,6 @@ function browserifyOpts (entries) {
     packageCache: {},
     cache: {}
   }
-}
-
-function find (rootname, arr, done) {
-  if (!arr.length) return done(new Error('Could not find files'))
-  var filename = arr[0]
-  var newArr = arr.slice(1)
-  findup(rootname, filename, function (err, dirname) {
-    if (err) return find(rootname, newArr, done)
-    done(null, path.join(dirname, filename))
-  })
 }
 
 function fileEnv (state) {

--- a/lib/graph-service-worker.js
+++ b/lib/graph-service-worker.js
@@ -113,8 +113,10 @@ function fileEnv (state) {
   ]
   var style = [`${state.styles.bundle.hash.toString('hex').slice(0, 16)}/bundle.css`]
   var assets = split(state.assets.list.buffer)
-  var doc = split(state.documents.list.buffer)
-  var manifest = ['/manifest.json']
+  var doc = split(state.documents.list.buffer).map(function (url) {
+    return url.slice(1)
+  })
+  var manifest = ['manifest.json']
 
   var files = [].concat(script, style, assets, doc, manifest)
   files = files.filter(function (file) {


### PR DESCRIPTION
I have to handle the urls before cache it in my `sw.js`. eg. format of '/login' and 'assets/avatar.png' is different.
so I remove the first `'/'` from '/manifest.json' and url of server-rendered route.

## Checklist
- [x] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context
<!-- Is this related to any GitHub issue(s)? -->
No

## Semver Changes
<!-- Which semantic version change would you recommend? -->
Patch