### PR TITLE
swap `open` with `opn`

### DIFF
--- a/lib/cmd-inspect.js
+++ b/lib/cmd-inspect.js
@@ -1,5 +1,5 @@
 var disc = require('disc')
-var open = require('open')
+var open = require('opn')
 var path = require('path')
 var pump = require('pump')
 var os = require('os')

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "nanoraf": "^3.0.1",
     "nanotiming": "^7.2.0",
     "on-idle": "^3.1.4",
-    "open": "^0.0.5",
+    "opn": "^5.3.0",
     "p-wait-all": "^1.0.0",
     "pino": "^4.10.4",
     "pino-colada": "^1.4.2",


### PR DESCRIPTION
This change swaps out `open` with `opn` which has a compatible API, but
is cross platform, safer, and maintained.

<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

**Choose one:** is this a 🐛 bug fix, a 🙋 feature, or a 🔦 documentation change?

🐛

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass

## Context
<!-- Is this related to any GitHub issue(s)? -->
https://nodesecurity.io/advisories/663

## Semver Changes
<!-- Which semantic version change would you recommend? -->
patch
