### PR TITLE
enable `reload` only when watch is true

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,8 +97,14 @@ function Bankai (entry, opts) {
   })
 
   // Insert nodes into the graph.
+  var documentNodeDepList = [ 'assets:list', 'manifest:bundle', 'styles:bundle', 'scripts:bundle' ]
+
+  if (opts.watch !== false) {
+    documentNodeDepList.push('reload:bundle')
+    this.graph.node('reload', reloadNode)
+  }
   this.graph.node('assets', assetsNode)
-  this.graph.node('documents', [ 'assets:list', 'manifest:bundle', 'styles:bundle', 'scripts:bundle', 'reload:bundle' ], documentNode)
+  this.graph.node('documents', documentNodeDepList, documentNode)
   this.graph.node('manifest', manifestNode)
   this.graph.node('scripts', scriptNode)
   this.graph.node('reload', reloadNode)


### PR DESCRIPTION
🙋 `reload` is useless when run `bankai build`, this shave about 500ms

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
