### PR TITLE
enable `reload` only when watch is true

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,11 +97,16 @@ function Bankai (entry, opts) {
   })
 
   // Insert nodes into the graph.
+  var documentsDepList = [ 'assets:list', 'manifest:bundle', 'styles:bundle', 'scripts:bundle' ]
+
+  if (opts.watch !== false) {
+    documentsDepList.push('reload:bundle')
+    this.graph.node('reload', reloadNode)
+  }
   this.graph.node('assets', assetsNode)
-  this.graph.node('documents', [ 'assets:list', 'manifest:bundle', 'styles:bundle', 'scripts:bundle', 'reload:bundle' ], documentNode)
+  this.graph.node('documents', documentsDepList, documentNode)
   this.graph.node('manifest', manifestNode)
   this.graph.node('scripts', scriptNode)
-  this.graph.node('reload', reloadNode)
   this.graph.node('service-worker', [ 'assets:list', 'styles:bundle', 'scripts:bundle', 'documents:list' ], serviceWorkerNode)
   this.graph.node('styles', [ 'scripts:style', 'scripts:bundle' ], styleNode)
 

--- a/lib/graph-document.js
+++ b/lib/graph-document.js
@@ -119,7 +119,7 @@ function node (state, createEdge) {
       // TODO: apple touch icons
       // TODO: favicons
 
-      if (state.metadata.reload) {
+      if (state.metadata.reload && state.metadata.watch) {
         header.push(reloadTag({ bundle: state.reload.bundle.buffer }))
       }
 


### PR DESCRIPTION
🙋 `reload` is useless when run `bankai build`, this shave about 500ms

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context
No

## Semver Changes
No
