### PR TITLE
Init bankai after mkdirp

### DIFF
--- a/lib/cmd-build.js
+++ b/lib/cmd-build.js
@@ -22,7 +22,8 @@ function build (entry, outdir, opts) {
   }
 
   if (!outdir) {
-    outdir = path.join(utils.dirname(entry), 'dist')
+    var dirname = path.extname(entry) === '' ? entry : utils.dirname(entry)
+    outdir = path.join(dirname, 'dist')
   }
 
   mkdirp(outdir, function (err) {

--- a/lib/cmd-build.js
+++ b/lib/cmd-build.js
@@ -20,15 +20,16 @@ function build (entry, outdir, opts) {
     watch: false,
     base: opts.base
   }
-  var compiler = bankai(entry, bankaiOpts)
-  var log = compiler.log
 
   if (!outdir) {
-    outdir = path.join(compiler.dirname, 'dist')
+    outdir = path.join(utils.dirname(entry), 'dist')
   }
 
   mkdirp(outdir, function (err) {
     if (err) return console.error(err)
+
+    var compiler = bankai(entry, bankaiOpts)
+    var log = compiler.log
 
     log.info('Compiling & compressing files\n')
     created(compiler.dirname, outdir + '/')


### PR DESCRIPTION
This is a 🐛 

When I was trying to add the faviconTag to the document I found this bug. I created a `faviconNode`, called `createEdge()` inside it, then the graph's change event was emited, then it [emits the compiler's change event](https://github.com/choojs/bankai/blob/master/index.js#L56) immediately, but at this moment, [compiler's change event](https://github.com/choojs/bankai/blob/master/lib/cmd-build.js#L47) has not yet been listened.

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context
No

## Semver Changes
minor
