### PR TITLE
check is turbolinks app

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var utils = require('./lib/utils')
 var assetsNode = require('./lib/graph-assets')
 var documentNode = require('./lib/graph-document')
 var manifestNode = require('./lib/graph-manifest')
+var packageJsonNode = require('./lib/graph-package-json')
 var reloadNode = require('./lib/graph-reload')
 var scriptNode = require('./lib/graph-script')
 var serviceWorkerNode = require('./lib/graph-service-worker')
@@ -98,7 +99,8 @@ function Bankai (entry, opts) {
 
   // Insert nodes into the graph.
   this.graph.node('assets', assetsNode)
-  this.graph.node('documents', [ 'assets:list', 'manifest:bundle', 'styles:bundle', 'scripts:bundle', 'reload:bundle' ], documentNode)
+  this.graph.node('package-json', packageJsonNode)
+  this.graph.node('documents', [ 'assets:list', 'package-json:list', 'manifest:bundle', 'styles:bundle', 'scripts:bundle', 'reload:bundle' ], documentNode)
   this.graph.node('manifest', manifestNode)
   this.graph.node('scripts', scriptNode)
   this.graph.node('reload', reloadNode)

--- a/lib/graph-document.js
+++ b/lib/graph-document.js
@@ -100,7 +100,7 @@ function node (state, createEdge) {
     function ontemplate (filename, html) {
       var d = documentify(filename, html)
       var header = [
-        viewportTag(),
+        viewportTag({ list: state['package-json'].list }),
         scriptTag({ hash: state.scripts.bundle.hash, base: base }),
         hasDynamicScripts && dynamicScriptsTag({
           bundleNames: state.scripts.bundle.dynamicBundles,
@@ -198,9 +198,12 @@ function manifestTag (opts) {
   `.replace(/\n +/g, '')
 }
 
-function viewportTag () {
+function viewportTag (opts) {
+  var list = JSON.parse(opts.list.buffer.toString())
+
   return `
     <meta charset="utf-8">
+    ${list.hasTurbolinksDep ? '<meta name="turbolinks-visit-control" content="reload">' : ''}
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
   `.replace(/\n +/g, '')
 }

--- a/lib/graph-package-json.js
+++ b/lib/graph-package-json.js
@@ -1,0 +1,29 @@
+var findup = require('@choojs/findup')
+var path = require('path')
+var fs = require('fs')
+
+module.exports = node
+
+function node (state, createEdge, emit) {
+  findup(state.metadata.dirname, 'package.json', function (err, dir) {
+    if (err) {
+      createEdge('list', Buffer.from(JSON.stringify({})))
+      return
+    }
+    fs.readFile(path.join(dir, 'package.json'), function (err, json) {
+      if (err) {
+        createEdge('list', Buffer.from(JSON.stringify({})))
+        return
+      }
+
+      try {
+        var pkg = JSON.parse(json)
+        var hasTurbolinksDep = Boolean((pkg.dependencies && pkg.dependencies.turbolinks) ||
+          (pkg.devDependencies && pkg.devDependencies.turbolinks))
+        createEdge('list', Buffer.from(JSON.stringify({ hasTurbolinksDep })))
+      } catch (err) {
+        if (err) createEdge('list', Buffer.from(JSON.stringify({})))
+      }
+    })
+  })
+}

--- a/test/document.js
+++ b/test/document.js
@@ -22,6 +22,7 @@ tape('renders some HTML', function (assert) {
     <html lang="en-US" dir="ltr">
       <head>
         <meta charset="utf-8">
+        <meta name="turbolinks-visit-control" content="reload">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <script src="/__SCRIPTS_HASH__/bundle.js" integrity="sha512-__SCRIPTS_INTEGRITY__" defer></script>
         <script>;(function(a){"use strict";var b=function(b,c,d){function e(a){return h.body?a():void setTimeout(function(){e(a)})}function f(){i.addEventListener&&i.removeEventListener("load",f),i.media=d||"all"}var g,h=a.document,i=h.createElement("link");if(c)g=c;else{var j=(h.body||h.getElementsByTagName("head")[0]).childNodes;g=j[j.length-1]}var k=h.styleSheets;i.rel="stylesheet",i.href=b,i.media="only x",e(function(){g.parentNode.insertBefore(i,c?g:g.nextSibling)});var l=function(a){for(var b=i.href,c=k.length;c--;)if(k[c].href===b)return a();setTimeout(function(){l(a)})};return i.addEventListener&&i.addEventListener("load",f),i.onloadcssdefined=l,l(f),i};"undefined"!=typeof exports?exports.loadCSS=b:a.loadCSS=b})("undefined"!=typeof global?global:this);;(function(a){if(a.loadCSS){var b=loadCSS.relpreload={};if(b.support=function(){try{return a.document.createElement("link").relList.supports("preload")}catch(b){return!1}},b.poly=function(){for(var b=a.document.getElementsByTagName("link"),c=0;c<b.length;c++){var d=b[c];"preload"===d.rel&&"style"===d.getAttribute("as")&&(a.loadCSS(d.href,d,d.getAttribute("media")),d.rel=null)}},!b.support()){b.poly();var c=a.setInterval(b.poly,300);a.addEventListener&&a.addEventListener("load",function(){b.poly(),a.clearInterval(c)}),a.attachEvent&&a.attachEvent("onload",function(){a.clearInterval(c)})}}})(this);</script>
@@ -39,12 +40,22 @@ tape('renders some HTML', function (assert) {
     1 + 1
   `
 
+  var packageJson = dedent`
+    {
+      "dependencies": {
+        "turbolinks": "^5.1.1"
+      }
+    }
+  `
+
   var dirname = 'document-pipeline-' + (Math.random() * 1e4).toFixed()
   tmpDirname = path.join(__dirname, '../tmp', dirname)
   var tmpScriptname = path.join(tmpDirname, 'index.js')
+  var tmpPackageJsonname = path.join(tmpDirname, 'package.json')
 
   mkdirp.sync(tmpDirname)
   fs.writeFileSync(tmpScriptname, script)
+  fs.writeFileSync(tmpPackageJsonname, packageJson)
 
   var compiler = bankai(tmpScriptname, { watch: false })
   compiler.documents('/', function (err, res) {


### PR DESCRIPTION
This is a 🙋 feature.

Check whether is a turbolinks app, then add relative meta tag.

Create a `graph-package-json.js` to check it, because the document node dependents on it, if this is a turbolinks app, will add `<meta name="turbolinks-visit-control" content="reload">` to `<head>`. May combine it with `is-electron-projects.js` into one file in the future.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [x] tests and/or benchmarks are included

## Context
No

## Semver Changes
minor
