### PR TITLE
Upgrade to brfs v2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-core": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "babelify": "^8.0.0",
-    "brfs": "^1.4.4",
+    "brfs": "^2.0.0",
     "brotli": "^1.3.2",
     "browserify": "^16.0.0",
     "browserslist": "^3.1.1",


### PR DESCRIPTION
This version does scope tracking and does not depend on a vulnerable
version of static-eval.

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass

Patch