### PR TITLE
🐛Apply sheetify and glslify after babelify

### DIFF
--- a/lib/graph-script.js
+++ b/lib/graph-script.js
@@ -55,9 +55,6 @@ function node (state, createEdge) {
     })
   }
 
-  b.ignore('sheetify/insert')
-  b.transform(sheetify)
-  b.transform(glslify)
 
   if (state.metadata.babelifyDeps) {
     // Dependencies should be transformed, but their .babelrc should be ignored.
@@ -86,6 +83,9 @@ function node (state, createEdge) {
     ]
   })
 
+  b.ignore('sheetify/insert')
+  b.transform(sheetify, { global: true })
+  b.transform(glslify, { global: true })
   b.transform(brfs, { global: true })
   b.transform(nanohtml, { global: true })
 

--- a/lib/graph-script.js
+++ b/lib/graph-script.js
@@ -55,7 +55,6 @@ function node (state, createEdge) {
     })
   }
 
-
   if (state.metadata.babelifyDeps) {
     // Dependencies should be transformed, but their .babelrc should be ignored.
     b.transform(tfilter(babelify, { include: /node_modules/ }), {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "selfsigned": "^1.10.2",
     "send": "^0.16.1",
     "server-router": "^6.0.0",
-    "sheetify": "^7.1.0",
+    "sheetify": "^7.4.0",
     "split-require": "^3.1.1",
     "split2": "^2.2.0",
     "strip-ansi": "^4.0.0",


### PR DESCRIPTION
Looks like otherwise Babelify is applied _after_ subject transforms.

This requires https://github.com/stackcss/sheetify/pull/156 to be merged first in order to *purifycss* is able to cleanup transpiled templates code. @yoshuawuyts Please take a look at it.