### PR TITLE
🐛 Update deprecated package `opn`

### DIFF
--- a/lib/cmd-inspect.js
+++ b/lib/cmd-inspect.js
@@ -1,5 +1,5 @@
 var disc = require('disc')
-var open = require('opn')
+var open = require('open')
 var path = require('path')
 var pump = require('pump')
 var os = require('os')

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "nanoraf": "^3.0.1",
     "nanotiming": "^7.2.0",
     "on-idle": "^3.1.4",
-    "opn": "^5.3.0",
+    "open": "^6.3.0",
     "p-wait-all": "^1.0.0",
     "pino": "^4.10.4",
     "pino-colada": "^1.4.2",


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

This somewhat of a 🐛 bug fix.

> **"The package has been renamed to `open`"**
> - https://www.npmjs.com/package/opn

---

For me updating the dependency also solved the bug where `inspect` would break because it couldn't open a browser window (thanks @goto-bus-stop for pointing it out ✨).

```bash
user@computer ~/software-v2/node $ npm run inspect

> software-v2@1.0.0 inspect /home/user/software-v2/node
> bankai inspect client.js

/tmp/1559101935126.html
(node:2571) UnhandledPromiseRejectionWarning: Error: Exited with code 3
    at ChildProcess.cp.once.code (/home/user/software-v2/node/node_modules/opn/index.js:85:13)
    at Object.onceWrapper (events.js:281:20)
    at ChildProcess.emit (events.js:193:13)
    at maybeClose (internal/child_process.js:999:16)
    at Socket.stream.socket.on (internal/child_process.js:403:11)
    at Socket.emit (events.js:193:13)
    at Pipe._handle.close (net.js:614:12)
(node:2571) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:2571) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

---

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass

## Context
No related issues.

## Semver Changes
Patch.