### PR TITLE
Add style tag for disabled javascript

### DIFF
--- a/lib/graph-document.js
+++ b/lib/graph-document.js
@@ -6,6 +6,7 @@ var resolve = require('resolve')
 var crypto = require('crypto')
 var pump = require('pump')
 var path = require('path')
+var dedent = require('dedent')
 
 var critical = require('inline-critical-css')
 var documentify = require('documentify')
@@ -182,7 +183,10 @@ function dynamicScriptsTag (opts) {
 function styleTag (opts) {
   var hex = opts.hash.toString('hex').slice(0, 16)
   var link = `${opts.base || ''}/${hex}/bundle.css`
-  return `<link rel="preload" as="style" href="${link}" onload="this.rel='stylesheet'">`
+  return dedent`
+    <link rel="preload" as="style" href="${link}" onload="this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="${link}"></noscript>
+  `
 }
 
 function loadFontsTag (opts) {


### PR DESCRIPTION
If browser has javascript disabled, the css will not be loaded since we use `onload="this.rel='stylesheet'` on the link tag.
I simply added a noscript tag including the link to the css.