### PR TITLE
Add support for typescript with esModuleInterop

### DIFF
--- a/lib/graph-script.js
+++ b/lib/graph-script.js
@@ -59,6 +59,9 @@ function node (state, createEdge) {
   b.transform(sheetify)
   b.transform(glslify)
 
+  b.transform(brfs, { global: true })
+  b.transform(nanohtml, { global: true })
+
   if (state.metadata.babelifyDeps) {
     // Dependencies should be transformed, but their .babelrc should be ignored.
     b.transform(tfilter(babelify, { include: /node_modules/ }), {
@@ -85,9 +88,6 @@ function node (state, createEdge) {
       }]
     ]
   })
-
-  b.transform(brfs, { global: true })
-  b.transform(nanohtml, { global: true })
 
   if (!fullPaths) b.plugin(cssExtract, { out: bundleStyles })
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "keypress": "^0.2.1",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
-    "nanohtml": "^1.2.4",
+    "nanohtml": "^1.7.0",
     "nanologger": "^2.0.0",
     "nanoraf": "^3.0.1",
     "nanotiming": "^7.2.0",


### PR DESCRIPTION
## Checklist
- [x] tests pass
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context
Fixes #536 

## Semver Changes
I don't know if it is a breaking change or not. At first, I tough upgrading nanohtml would be sufficient but I had to move the transformation before babel as well to make it work. I am kindly asking for code review and recommendation to make this fix better.